### PR TITLE
Add CI workflow for PHP 7.2-8.4, setup PHP, validate composer.json, c…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main, '*.x']
+  pull_request:
+    branches: [main, '*.x']
+
+permissions:
+  contents: read
+
+jobs:
+  qa:
+    name: PHP ${{ matrix.php }} / QA
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring
+          coverage: none
+          tools: composer:v2
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ runner.os }}-${{ matrix.php }}-${{ hashFiles('composer.json') }}
+          restore-keys: |
+            composer-${{ runner.os }}-${{ matrix.php }}-
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress --no-interaction
+
+      - name: Coding standards (phpcs)
+        run: composer cs-ci
+
+      - name: Static analysis (PHPStan)
+        run: composer stan
+
+      - name: Unit tests (PHPUnit)
+        run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 /.vs/
 /vendor/
 /composer.lock
+/build/
+/.phpunit.cache/
+.phpunit.result.cache
+/.php-cs-fixer.cache

--- a/README.md
+++ b/README.md
@@ -1,53 +1,166 @@
-# Console
+# InitPHP Console
 
-A simple helper library for writing console/CLI applications in PHP.
+A small, dependency-free helper library for writing console / CLI applications in PHP — command routing, typed arguments, coloured output, interactive questions and a styleable ANSI table renderer.
 
-Starting with **2.1**, this package also ships the ANSI-coloured table renderer that used to be distributed as the separate [`initphp/cli-table`](https://github.com/InitPHP/CLITable) package (now deprecated). See the [migration section](#migrating-from-initphpcli-table) below if you are coming from that package.
+[![CI](https://github.com/InitPHP/Console/actions/workflows/ci.yml/badge.svg)](https://github.com/InitPHP/Console/actions/workflows/ci.yml)
+[![Latest Stable Version](https://poser.pugx.org/initphp/console/v/stable)](https://packagist.org/packages/initphp/console)
+[![Total Downloads](https://poser.pugx.org/initphp/console/downloads)](https://packagist.org/packages/initphp/console)
+[![License](https://poser.pugx.org/initphp/console/license)](./LICENSE)
+[![PHP Version Require](https://poser.pugx.org/initphp/console/require/php)](https://packagist.org/packages/initphp/console)
+
+> Starting with **2.1** this package also ships the ANSI table renderer that used to be distributed as the separate [`initphp/cli-table`](https://github.com/InitPHP/CLITable) package (now deprecated). See [Migrating from `initphp/cli-table`](#migrating-from-initphpcli-table).
+
+## Features
+
+- **Command routing** — register commands as closures or as classes extending `Command`.
+- **Grouped help** — automatic `help` / `list` overview and per-command `--help` usage.
+- **Typed arguments** — declare `--name` arguments with a type (`INT`, `FLOAT`, `BOOL`, …), a default and an optional/required flag; values are validated automatically.
+- **Input parsing** — long arguments (`--name=value`), short options (`-v`, `-abc`, `-k=value`) and bare positional segments, with automatic scalar type casting.
+- **Coloured output** — 16/256-colour SGR helpers, message styles (`error`, `success`, `warning`, `info`), key/value lists and a progress bar.
+- **Interactive prompts** — free-form `ask()` and option-constrained `question()`.
+- **Table rendering** — a styleable, multibyte-aware ASCII/ANSI table.
+- **Testable I/O** — output and input streams are injectable, so commands can be unit tested without touching `STDOUT`/`STDIN`.
 
 ## Requirements
 
-- PHP 7.2 or higher
+- PHP **7.2** or higher
+- `ext-mbstring` *(optional)* — improves table alignment for multibyte (UTF-8) values
 
 ## Installation
 
-```
+```bash
 composer require initphp/console
 ```
 
-## Usage
+## Quick start
+
+Create an entry script (e.g. `console.php`):
 
 ```php
 #!/usr/bin/env php
 <?php
-require_once __DIR__ . '/../vendor/autoload.php';
-use \InitPHP\Console\{Application, Input, Output};
 
-$console = new Application("My Console Application", '1.0');
+require_once __DIR__ . '/vendor/autoload.php';
 
-// Register commands ...
+use InitPHP\Console\{Application, Input, Output};
 
-// hello -name=John
+$console = new Application('My Console Application', '1.0.0');
+
+// A closure command:  php console.php hello --name=John
 $console->register('hello', function (Input $input, Output $output) {
-    if ($input->hasArgument('name')) {
-        $output->writeln('Hello {name}', [
-            'name'  => $input->getArgument('name')
-        ]);
-    } else {
-        $output->writeln('Hello World!');
-    }
+    $output->writeln('Hello {name}!', [
+        'name' => $input->getArgument('name', 'World'),
+    ]);
 }, 'Says hello.');
-
 
 $console->run();
 ```
 
+Run it:
+
+```bash
+php console.php hello --name=John   # Hello John!
+php console.php hello               # Hello World!
+php console.php list                # Show all registered commands
 ```
-php console.php list
+
+## Terminology
+
+This library distinguishes three kinds of tokens that follow the command name:
+
+| Token            | Shape                          | Accessor        |
+|------------------|--------------------------------|-----------------|
+| **Argument**     | `--name`, `--name=value`       | `getArgument()` |
+| **Option**       | `-v`, `-abc`, `-key=value`     | `getOption()`   |
+| **Segment**      | bare value, e.g. `migrate`     | `getSegment()`  |
+
+> **Note:** here `--long` tokens are called *arguments* and `-short` tokens are called *options*. This is the opposite of some other frameworks — keep it in mind when porting code.
+
+All scalar values are cast automatically: `"true"`/`"false"`/`"yes"`/`"no"` → `bool`, `"null"` → `null`, integer/decimal strings → `int`/`float`.
+
+## Class-based commands
+
+For anything beyond a one-liner, extend `Command`:
+
+```php
+use InitPHP\Console\{Command, Input, InputArgument, Output};
+
+class GreetCommand extends Command
+{
+    public $command = 'app:greet';
+
+    public function definition(): string
+    {
+        return 'Greets a person.';
+    }
+
+    public function help(): string
+    {
+        return 'Prints a friendly greeting to the given name.';
+    }
+
+    public function arguments(): array
+    {
+        return [
+            new InputArgument('name', InputArgument::STR, 'World', true, 'Who to greet.'),
+        ];
+    }
+
+    public function execute(Input $input, Output $output)
+    {
+        $output->success('Hi ' . $input->getArgument('name'));
+    }
+}
+
+$console->register(GreetCommand::class);
 ```
+
+Declared `arguments()` are validated *before* `execute()` runs: missing required arguments or values that do not match the declared type abort the command with an error.
+
+```bash
+php console.php app:greet --name=Ada
+php console.php app:greet --help        # shows the generated usage + parameters
+```
+
+## Output
+
+```php
+$output->writeln('Plain line');
+$output->writeln('Coloured', [], [Output::COLOR_GREEN, Output::BOLD]);
+$output->write('No newline; {token} interpolated', ['token' => 42]);
+
+$output->error('Something failed');
+$output->success('All good');
+$output->warning('Heads up');
+$output->info('FYI');
+
+$output->list(['host' => 'localhost', 'port' => 8080]);
+
+for ($i = 0; $i <= 100; $i += 10) {
+    $output->progressBar($i, 100);
+    usleep(50_000);
+}
+```
+
+## Interactive prompts
+
+```php
+$name = $output->ask('What is your name?');
+
+use InitPHP\Console\Question;
+
+$question = (new Question())
+    ->setQuestion('Continue? (yes/no)')
+    ->setOptions(['yes', 'no'])
+    ->optional()
+    ->setDefault('no');
+
+$answer = $output->question($question);
+```
+
+Typing `exit` or `quit` at any prompt terminates the application.
 
 ## Rendering tables
-
-This package ships a styleable ASCII/ANSI table renderer under `\InitPHP\Console\Utils\Table`:
 
 ```php
 use InitPHP\Console\Utils\Table;
@@ -58,38 +171,60 @@ $table = Table::create()
     ->setCellStyle(Table::COLOR_GREEN);
 
 $table->row(['id' => 1, 'name' => 'Matthew S.', 'email' => 'matthew@example.com', 'status' => true])
-      ->row(['id' => 2, 'name' => 'Millie J.',  'email' => 'millie@example.com',  'status' => false])
-      ->row(['id' => 3, 'name' => 'Regina G.',  'email' => 'regina@example.com',  'status' => true]);
+      ->row(['id' => 2, 'name' => 'Millie J.',  'email' => 'millie@example.com',  'status' => false]);
 
 echo $table; // or $table->getContent()
 ```
 
-The renderer is intentionally lightweight: it stringifies non-string cell values (`[NULL]`, `[TRUE]`, `[FALSE]`, `[CALLABLE]`, `[RESOURCE]`, class name for objects), auto-sizes columns, and emits standard SGR escape sequences. `mb_strlen()` is used when available so multibyte values align correctly.
+Non-string cell values are stringified (`[NULL]`, `[TRUE]`, `[FALSE]`, `[ARRAY]`, `[CALLABLE]`, `[RESOURCE]`, or the class name for objects), columns are auto-sized, and `mb_strlen()` is used when available so multibyte values align correctly.
+
+## Documentation
+
+In-depth, example-driven guides live in [`docs/`](./docs):
+
+1. [Getting started](./docs/01-getting-started.md)
+2. [Commands](./docs/02-commands.md)
+3. [Input: arguments, options & segments](./docs/03-input.md)
+4. [Typed input arguments](./docs/04-input-arguments.md)
+5. [Output & formatting](./docs/05-output.md)
+6. [Interactive questions](./docs/06-questions.md)
+7. [Tables](./docs/07-tables.md)
+8. [Migrating from `initphp/cli-table`](./docs/08-migrating-from-cli-table.md)
 
 ## Migrating from `initphp/cli-table`
 
-The standalone [`initphp/cli-table`](https://github.com/InitPHP/CLITable) package has been merged into this one starting with **2.1** and is now deprecated.
+The standalone [`initphp/cli-table`](https://github.com/InitPHP/CLITable) package has been merged into this one as of **2.1** and is now deprecated.
 
-If your code currently uses `\InitPHP\CLITable\Table`, **no source changes are required** — this package ships a `class_alias` that keeps the old fully-qualified class name working. Just switch your dependency:
+If your code uses `\InitPHP\CLITable\Table`, **no source changes are required** — this package ships a `class_alias` keeping the old fully-qualified name working. Just switch the dependency:
 
 ```diff
 - "initphp/cli-table": "^1.0",
 + "initphp/console": "^2.1"
 ```
 
-(`initphp/console:^2.1` declares a Composer `replace` for `initphp/cli-table`, so Composer will not install both side-by-side.)
-
-When you next touch the code, prefer the new canonical namespace:
+(`initphp/console` declares a Composer `replace` for `initphp/cli-table`, so the two will never be installed side by side.) When you next touch the code, prefer the canonical namespace:
 
 ```php
 // Before
 use InitPHP\CLITable\Table;
-
 // After
 use InitPHP\Console\Utils\Table;
 ```
 
-The alias is intended as a transition aid and may be removed in a future major release.
+The alias is a transition aid and may be removed in a future major release. See the [migration guide](./docs/08-migrating-from-cli-table.md) for details.
+
+## Testing & quality
+
+```bash
+composer test     # PHPUnit
+composer cs       # PHP_CodeSniffer (PSR-12)
+composer stan     # PHPStan (level 6)
+composer qa       # all of the above
+```
+
+## Contributing
+
+Contributions are welcome. Please run `composer qa` before opening a pull request. See the organisation [contributing guidelines](https://github.com/InitPHP/.github/blob/main/CONTRIBUTING.md).
 
 ## Credits
 
@@ -97,4 +232,4 @@ The alias is intended as a transition aid and may be removed in a future major r
 
 ## License
 
-Copyright &copy; 2022 [MIT License](./LICENSE)
+Released under the [MIT License](./LICENSE). Copyright © 2022 InitPHP.

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,23 @@
 {
     "name": "initphp/console",
-    "description": "A simple helper library for writing console/CLI applications in PHP. As of 2.1 this package also ships the table renderer previously distributed as initphp/cli-table.",
+    "description": "A simple helper library for writing console/CLI applications in PHP, including a styleable ANSI table renderer (formerly initphp/cli-table).",
     "type": "library",
     "license": "MIT",
-    "autoload": {
-        "psr-4": {
-            "InitPHP\\Console\\": "src/"
-        },
-        "files": [
-            "src/aliases.php"
-        ]
+    "keywords": [
+        "console",
+        "cli",
+        "command-line",
+        "command",
+        "terminal",
+        "ansi",
+        "table",
+        "initphp"
+    ],
+    "homepage": "https://github.com/InitPHP/Console",
+    "support": {
+        "issues": "https://github.com/InitPHP/Console/issues",
+        "source": "https://github.com/InitPHP/Console",
+        "docs": "https://github.com/InitPHP/Console/tree/main/docs"
     },
     "authors": [
         {
@@ -19,11 +27,48 @@
             "homepage": "https://www.muhammetsafak.com.tr"
         }
     ],
-    "minimum-stability": "stable",
     "require": {
         "php": ">=7.2"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5",
+        "squizlabs/php_codesniffer": "^3.7",
+        "phpstan/phpstan": "^1.11"
+    },
+    "suggest": {
+        "ext-mbstring": "Improves table column alignment for multibyte (UTF-8) cell values."
+    },
+    "autoload": {
+        "psr-4": {
+            "InitPHP\\Console\\": "src/"
+        },
+        "files": [
+            "src/aliases.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Test\\InitPHP\\Console\\": "tests/"
+        }
+    },
     "replace": {
         "initphp/cli-table": "*"
+    },
+    "scripts": {
+        "test": "phpunit",
+        "test:coverage": "phpunit --coverage-text --coverage-html=build/coverage",
+        "cs": "phpcs",
+        "cs-ci": "phpcs --warning-severity=0",
+        "cs-fix": "phpcbf",
+        "stan": "phpstan analyse",
+        "qa": [
+            "@cs-ci",
+            "@stan",
+            "@test"
+        ]
+    },
+    "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
     }
 }

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -1,0 +1,91 @@
+# Getting started
+
+`initphp/console` helps you build command-line tools in PHP: it routes a command name to a handler, parses the tokens that follow it, and gives you helpers for coloured output, prompts and tables.
+
+## Installation
+
+```bash
+composer require initphp/console
+```
+
+Requires PHP 7.2+. The optional `ext-mbstring` extension improves table alignment for multibyte text.
+
+## Your first application
+
+Create an executable entry script, for example `bin/console`:
+
+```php
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use InitPHP\Console\{Application, Input, Output};
+
+$console = new Application('Acme CLI', '1.0.0');
+
+$console->register('greet', function (Input $input, Output $output) {
+    $output->writeln('Hello {name}!', [
+        'name' => $input->getArgument('name', 'World'),
+    ]);
+}, 'Greets someone.');
+
+$console->run();
+```
+
+Make it runnable and try it:
+
+```bash
+chmod +x bin/console
+
+php bin/console greet --name=Ada   # Hello Ada!
+php bin/console greet              # Hello World!
+php bin/console list               # Overview of all commands
+```
+
+## How dispatch works
+
+`Application::run()`:
+
+1. Reads the token list (from the global `$argv`, or from the array you pass to `run()`).
+2. Drops the script name (`$argv[0]`) and takes the next token as the **command name**.
+3. Wraps the remaining tokens in an [`Input`](03-input.md) object and creates an [`Output`](05-output.md).
+4. Dispatches:
+   - `help` / `list` → renders the command overview.
+   - a registered command with the `--help` argument → renders that command's usage.
+   - a registered command → runs its handler.
+   - anything else → prints `The command was not found.`
+
+`run()` returns `true` when a command (or help) ran and `false` when no command was supplied or nothing matched.
+
+## Passing the token list explicitly
+
+`run()` accepts an optional array, which makes the application trivial to drive from tests or another script:
+
+```php
+$console->run(['bin/console', 'greet', '--name=Ada']);
+```
+
+When omitted, the global `$argv` is used (just like a normal CLI program).
+
+## Injecting output
+
+The constructor accepts an optional `Output` instance. Inject one backed by an in-memory stream to capture everything a command prints:
+
+```php
+use InitPHP\Console\Output;
+
+$stream = fopen('php://memory', 'r+');
+$console = new Application('Acme CLI', '1.0.0', new Output($stream));
+$console->run(['bin/console', 'greet', '--name=Ada']);
+
+rewind($stream);
+echo stream_get_contents($stream);
+```
+
+## Next steps
+
+- [Commands](02-commands.md) — closures vs. class-based commands and grouping.
+- [Input](03-input.md) — arguments, options and segments.
+- [Typed input arguments](04-input-arguments.md) — validation and defaults.
+- [Output](05-output.md), [Questions](06-questions.md), [Tables](07-tables.md).

--- a/docs/02-commands.md
+++ b/docs/02-commands.md
@@ -1,0 +1,126 @@
+# Commands
+
+A command is the unit of work the application dispatches to. You can register a command either as a **closure** or as a **class** extending `Command`.
+
+## Closure commands
+
+```php
+use InitPHP\Console\{Input, Output};
+
+$console->register('cache:clear', function (Input $input, Output $output) {
+    // ... do the work ...
+    $output->success('Cache cleared.');
+}, 'Clears the application cache.');
+```
+
+`register()` signature:
+
+```php
+public function register(
+    string   $command,        // command name, e.g. "cache:clear"
+    ?callable $execute = null, // the handler
+    string   $definition = '' // short description for the listing
+): self
+```
+
+The handler is called with `(Input $input, Output $output)`. The return value is ignored. `register()` returns the application, so calls can be chained.
+
+## Class-based commands
+
+For richer commands, extend `InitPHP\Console\Command`:
+
+```php
+use InitPHP\Console\{Command, Input, InputArgument, Output};
+
+final class MakeModelCommand extends Command
+{
+    public $command = 'make:model';
+
+    public function definition(): string
+    {
+        return 'Generates a model class.';
+    }
+
+    public function help(): string
+    {
+        return 'Creates a new model in app/Models from a name argument.';
+    }
+
+    public function arguments(): array
+    {
+        return [
+            new InputArgument('name', InputArgument::STR, '', false, 'Model class name.'),
+            new InputArgument('force', InputArgument::BOOL, false, true, 'Overwrite if it exists.'),
+        ];
+    }
+
+    public function execute(Input $input, Output $output)
+    {
+        $name = $input->getArgument('name');
+        $output->success("Model {$name} created.");
+    }
+}
+```
+
+Register it by class name — the application instantiates it and reads the metadata from the instance:
+
+```php
+$console->register(MakeModelCommand::class);
+```
+
+### The `Command` contract
+
+| Member          | Required | Purpose                                                                 |
+|-----------------|----------|-------------------------------------------------------------------------|
+| `$command`      | ✅       | The name the command is invoked by. Must be set or registration throws. |
+| `execute()`     | ✅       | Runs the command. Receives `(Input, Output)`.                           |
+| `definition()`  | ❌       | One-line description shown in the listing (defaults to `''`).           |
+| `help()`        | ❌       | Long help shown by `<command> --help`.                                  |
+| `arguments()`   | ❌       | Array of [`InputArgument`](04-input-arguments.md) declarations.         |
+
+Every entry returned by `arguments()` is validated **before** `execute()` runs. If a required argument is missing or a value fails its type check, the command aborts with an error and `execute()` is never called.
+
+## Grouping in the listing
+
+If a command name contains a colon, the prefix becomes a group heading in `php console list`:
+
+```php
+$console->register(MakeModelCommand::class);       // group: make
+$console->register('make:controller', $fn, '...'); // group: make
+$console->register('serve', $fn, 'Start server.'); // ungrouped
+```
+
+```
+[COMMANDS]
+
+make
+        make:model       : Generates a model class.
+        make:controller  : ...
+
+serve : Start server.
+```
+
+## Per-command help
+
+Any command supports an automatic usage screen via the `--help` argument:
+
+```bash
+php console make:model --help
+```
+
+```
+Creates a new model in app/Models from a name argument.
+
+[PARAMETERS]
+        --name   : Model class name.
+        --force  : Overwrite if it exists.
+
+[USAGE]
+        php console make:model --name=(STRING) [--force=(BOOL)]
+```
+
+Required parameters are shown bare; optional ones are wrapped in `[ ]`.
+
+## Reserved names
+
+`help` and `list` are reserved for the built-in overview and cannot be used as command names.

--- a/docs/03-input.md
+++ b/docs/03-input.md
@@ -1,0 +1,101 @@
+# Input: arguments, options & segments
+
+`Input` parses the tokens that follow the command name into three buckets and exposes them through a small, symmetric API.
+
+## The three token shapes
+
+| Shape                | Bucket    | Example                    |
+|----------------------|-----------|----------------------------|
+| `--name`             | argument  | `--verbose`                |
+| `--name=value`       | argument  | `--name=John`              |
+| `-x`                 | option    | `-v`                       |
+| `-xyz` (combined)    | option    | `-abc` → `a`, `b`, `c`     |
+| `-key=value`         | option    | `-level=5`                 |
+| bare token           | segment   | `migrate`, `42`            |
+
+> In this library `--long` tokens are **arguments** and `-short` tokens are **options** — the opposite of some other CLI frameworks.
+
+A token consisting only of dashes/whitespace (such as a lone `--`) carries no data and is skipped.
+
+## Automatic type casting
+
+Every value is normalised with `Helpers::strValueCast()`:
+
+| Input string             | Result        |
+|--------------------------|---------------|
+| `"true"`, `"yes"`        | `true`        |
+| `"false"`, `"no"`        | `false`       |
+| `"null"`                 | `null`        |
+| `"42"`, `"-7"`, `"+7"`   | `int`         |
+| `"3.14"`, `"3,14"`       | `float`       |
+| anything else            | `string`      |
+
+(Matching is case-insensitive. Both `.` and `,` are accepted as the decimal separator.)
+
+```php
+$input = new Input(['--age=30', '--active=true', '--ratio=1,5', 'deploy']);
+
+$input->getArgument('age');     // int(30)
+$input->getArgument('active');  // bool(true)
+$input->getArgument('ratio');   // float(1.5)
+$input->getSegment(0);          // string("deploy")
+```
+
+## Arguments API
+
+```php
+$input->hasArgument('name');              // bool
+$input->getArgument('name', $default);    // value or $default (null when omitted)
+$input->allArguments();                   // ['name' => 'John', ...]
+```
+
+A bare `--flag` (no `=value`) is stored as an empty string `''`, so `hasArgument('flag')` is `true` and `getArgument('flag')` is `''`.
+
+## Options API
+
+```php
+$input->hasOption('v');                   // bool
+$input->getOption('level', $default);     // value or $default
+$input->allOptions();                     // ['v' => 'v', 'level' => 5, ...]
+```
+
+Boolean short flags resolve to their own letter as the value:
+
+```php
+$input = new Input(['-abc']);
+$input->allOptions();   // ['a' => 'a', 'b' => 'b', 'c' => 'c']
+```
+
+## Segments API
+
+Segments are bare positional tokens, indexed in order:
+
+```php
+$input = new Input(['migrate', 'up', '3']);
+
+$input->getSegment(0);   // string("migrate")
+$input->getSegment(1);   // string("up")
+$input->getSegment(2);   // int(3)
+$input->allSegment();    // ['migrate', 'up', 3]
+```
+
+## Importing values
+
+`importArguments()` merges one or more `name => value` maps into the parsed arguments (later maps win). It is mainly used internally by [`InputArgument`](04-input-arguments.md) to write back resolved defaults, but it is available to you too:
+
+```php
+$input->importArguments(['name' => 'fallback'], ['env' => 'prod']);
+```
+
+## Programming to the interface
+
+`Input` implements `InitPHP\Console\InputInterface`. Type-hint the interface in your own helpers when you want to accept any compatible implementation:
+
+```php
+use InitPHP\Console\InputInterface;
+
+function resolveName(InputInterface $input): string
+{
+    return (string) $input->getArgument('name', 'World');
+}
+```

--- a/docs/04-input-arguments.md
+++ b/docs/04-input-arguments.md
@@ -1,0 +1,95 @@
+# Typed input arguments
+
+`InputArgument` lets a [class-based command](02-commands.md) declare the `--name` arguments it accepts, each with a type, a default value and an optional/required flag. The application validates them before calling `execute()`.
+
+## Constructing an argument
+
+```php
+use InitPHP\Console\InputArgument;
+
+new InputArgument(
+    string $name,          // name without dashes, e.g. "name"
+    string $type,          // one of the type constants below
+    mixed  $default,       // must satisfy $type
+    bool   $isOptional = true,
+    string $definition = '' // description for the help screen
+);
+```
+
+The constructor throws `InvalidArgumentException` if the type is unknown, or if the default value does not satisfy the type.
+
+## Types
+
+| Constant                  | Underlying value | Accepts                                                     |
+|---------------------------|------------------|-------------------------------------------------------------|
+| `InputArgument::ANY`      | `ANY`            | Any value.                                                  |
+| `InputArgument::INT`      | `INT`            | Integers.                                                   |
+| `InputArgument::FLOAT`    | `FLOAT`          | Floats.                                                     |
+| `InputArgument::NUMERIC`  | `NUMBER`         | Any numeric value (int, float or numeric string).          |
+| `InputArgument::BOOL`     | `BOOL`           | `true`/`false`, or `1`/`0` (coerced to bool).               |
+| `InputArgument::STR`      | `STRING`         | Strings (numeric/bool values are stringified).              |
+
+Because `Input` casts values first (see [Input](03-input.md)), `--age=30` already arrives as `int(30)` and passes the `INT` check; `--age=abc` stays a string and fails it.
+
+## How resolution works
+
+For each declared argument, `run()` does the following:
+
+1. Look the value up as an **argument** (`--name`), then as an **option** (`-name`).
+2. **Missing value:**
+   - optional → the default is stored and the command proceeds.
+   - required → an error is printed and the command aborts.
+3. **Present value:**
+   - valid → kept (a required argument given an empty `''`/`null` value falls back to its default).
+   - invalid + optional → replaced with the default.
+   - invalid + required → an error is printed and the command aborts.
+
+The resolved value is written back into `Input`, so `execute()` reads it with `$input->getArgument('name')`.
+
+## Example
+
+```php
+public function arguments(): array
+{
+    return [
+        new InputArgument('name',  InputArgument::STR,   '',    false, 'Required model name.'),
+        new InputArgument('count', InputArgument::INT,   1,     true,  'How many to create.'),
+        new InputArgument('force', InputArgument::BOOL,  false, true,  'Overwrite existing files.'),
+    ];
+}
+
+public function execute(Input $input, Output $output)
+{
+    $name  = $input->getArgument('name');   // guaranteed present (required)
+    $count = $input->getArgument('count');  // int, defaults to 1
+    $force = $input->getArgument('force');  // bool, defaults to false
+    // ...
+}
+```
+
+```bash
+php console make:model --name=User --count=3 --force=true
+php console make:model                 # error: The --name parameter is undefined.
+php console make:model --name=User     # count=1, force=false
+```
+
+## Zero and `false` are real values
+
+A required argument explicitly set to `0` keeps `0` (it is not mistaken for "missing" and replaced by the default):
+
+```php
+new InputArgument('retries', InputArgument::INT, 5, false);
+// php console run --retries=0   →  getArgument('retries') === 0
+```
+
+## Reading the metadata
+
+```php
+$arg = new InputArgument('age', InputArgument::INT, 18, false, 'The age.');
+
+$arg->getName();        // "--age"
+$arg->getType();        // "INT"
+$arg->getDefault();     // "18"  (string form, or null when no default)
+$arg->getDefinition();  // "The age."
+$arg->isOptional();     // false
+```

--- a/docs/05-output.md
+++ b/docs/05-output.md
@@ -1,0 +1,105 @@
+# Output & formatting
+
+`Output` writes coloured/styled text to an output stream and reads interactive answers from an input stream. Both streams default to `STDOUT`/`STDIN` but can be injected for testing.
+
+## Writing text
+
+```php
+$output->write('No trailing newline');
+$output->writeln('With a trailing newline');
+```
+
+### Placeholder interpolation
+
+The second argument is a context map; `{key}` tokens in the string are replaced. Array values and objects without `__toString()` are left untouched.
+
+```php
+$output->writeln('Deployed {app} to {env}', [
+    'app' => 'api',
+    'env' => 'production',
+]);
+// Deployed api to production
+```
+
+### Styling
+
+The third argument (for `writeln`) / fourth (for `write`) is a list of SGR codes applied to the whole string:
+
+```php
+$output->writeln('Important', [], [Output::COLOR_RED, Output::BOLD]);
+$output->writeln('On blue',   [], [Output::COLOR_WHITE, Output::BACKGROUND_BLUE]);
+```
+
+Available constants:
+
+- **Foreground:** `COLOR_DEFAULT`, `COLOR_BLACK`, `COLOR_RED`, `COLOR_GREEN`, `COLOR_YELLOW`, `COLOR_BLUE`, `COLOR_MAGENTA`, `COLOR_CYAN`, `COLOR_LIGHT_GRAY`, `COLOR_DARK_GRAY`, `COLOR_LIGHT_RED`, `COLOR_LIGHT_GREEN`, `COLOR_LIGHT_YELLOW`, `COLOR_LIGHT_BLUE`, `COLOR_LIGHT_MAGENTA`, `COLOR_LIGHT_CYAN`, `COLOR_WHITE`
+- **Background:** `BACKGROUND_BLACK`, `BACKGROUND_RED`, `BACKGROUND_GREEN`, `BACKGROUND_YELLOW`, `BACKGROUND_BLUE`, `BACKGROUND_MAGENTA`, `BACKGROUND_CYAN`
+- **Styles:** `BOLD`, `ITALIC`, `UNDERLINE`, `STRIKETHROUGH`
+
+## Message helpers
+
+Pre-styled, prefixed one-liners:
+
+```php
+$output->error('Disk full');       // [ERROR]   white on red, bold
+$output->success('Done');          // [SUCCESS] white on green, bold
+$output->warning('Low memory');    // [WARNING] white on yellow, bold
+$output->info('Cache warmed');     // [INFO]    cyan
+```
+
+Each accepts a context map too:
+
+```php
+$output->error('User {id} not found', ['id' => 42]);
+```
+
+## Key/value lists
+
+```php
+$output->list([
+    'Host' => 'localhost',
+    'Port' => 8080,
+    'TLS'  => 'enabled',
+]);
+```
+
+```
+Host : localhost
+Port : 8080
+TLS  : enabled
+```
+
+The optional second argument indents the whole block by N tab stops — used by the built-in help screen to indent grouped commands.
+
+## Progress bar
+
+`progressBar($done, $total)` renders a single, in-place updating line. `$total` must be greater than zero (a `0` total throws `InvalidArgumentException`).
+
+```php
+$total = 50;
+for ($i = 0; $i <= $total; $i++) {
+    $output->progressBar($i, $total);
+    usleep(20_000);
+}
+$output->writeln(''); // move off the progress line when finished
+```
+
+## Injecting streams (testing)
+
+Pass a stream resource to capture output or feed answers:
+
+```php
+$buffer = fopen('php://memory', 'r+');
+$output = new Output($buffer);
+
+$output->writeln('hello');
+
+rewind($buffer);
+echo stream_get_contents($buffer); // "\e[39mhello\e[0m\n"
+```
+
+The second constructor argument overrides the input stream used by [`ask()`/`question()`](06-questions.md).
+
+## Programming to the interface
+
+`Output` implements `InitPHP\Console\OutputInterface`; type-hint that interface where you only need the public surface.

--- a/docs/06-questions.md
+++ b/docs/06-questions.md
@@ -1,0 +1,87 @@
+# Interactive questions
+
+`Output` offers two ways to read input from the user: free-form `ask()` and the option-constrained `question()` built around the `Question` value object.
+
+## `ask()` — free-form input
+
+```php
+$name = $output->ask('What is your name?');
+```
+
+- The prompt is printed, then a line is read from the input stream.
+- The answer is run through the same [type casting](03-input.md#automatic-type-casting) as command input, so `"42"` comes back as `int(42)`, `"yes"` as `true`, etc.
+- Passing `false` as the second argument rejects an empty answer and keeps asking:
+
+```php
+$value = $output->ask('This cannot be empty:', false);
+```
+
+- Typing `exit` or `quit` terminates the application.
+
+## `question()` — constrained input
+
+`Question` describes the prompt, the set of acceptable answers, whether it is optional and a default. Configure it fluently:
+
+```php
+use InitPHP\Console\Question;
+
+$question = (new Question())
+    ->setQuestion('Pick an environment:')
+    ->setOptions(['dev', 'staging', 'prod'])
+    ->optional()
+    ->setDefault('dev');
+
+$env = $output->question($question);
+```
+
+Behaviour when an answer is submitted:
+
+1. If it matches one of the options → the (cast) answer is returned.
+2. If it is `exit`/`quit` → the application terminates.
+3. If the question is **optional** → the default is returned (or the raw answer when no default is set).
+4. If the question is **required** and nothing matched → the user is asked again.
+
+### Acceptable-answer matching
+
+`hasOption()` matches both the verbatim answer and its cast form, so string input lines up with boolean/numeric options:
+
+```php
+$q = new Question();          // default options: [true, false]
+$q->hasOption('true');        // true   ("true" casts to bool true)
+$q->hasOption('yes');         // true
+$q->hasOption('maybe');       // false
+```
+
+For yes/no prompts you can therefore rely on the defaults, or set explicit string options:
+
+```php
+(new Question())->setQuestion('Continue?')->setOptions(['yes', 'no']);
+```
+
+## The `Question` API
+
+| Method                         | Purpose                                                        |
+|--------------------------------|----------------------------------------------------------------|
+| `setQuestion(string)` / `getQuestion()` | The prompt text.                                      |
+| `setOptions(array)` / `getOptions()`    | Replace / read the acceptable answers.                |
+| `addOption(string)`            | Append a single acceptable answer.                             |
+| `hasOption(string)`            | Whether an answer is acceptable (verbatim or cast).            |
+| `optional()` / `notOptional()` / `isOptional()` | Toggle / read the optional flag.             |
+| `setDefault(mixed)` / `getDefault()` | Set / read the default answer.                           |
+| `hasDefault()`                 | Whether a default was set.                                     |
+| `Question::NO_DEFAULT`         | Sentinel returned by `getDefault()` when no default is set.    |
+
+> **`addOption()` compatibility note:** the method also accepts a legacy two-argument form `addOption($label, $value)`, where the second argument is the value that gets registered and the first is just a label. Prefer the single-argument form for new code.
+
+## Testing prompts
+
+Inject an input stream pre-seeded with the answers:
+
+```php
+$stdin = fopen('php://memory', 'r+');
+fwrite($stdin, "Ada\n");
+rewind($stdin);
+
+$output = new Output(STDOUT, $stdin);
+$output->ask('Name?'); // "Ada"
+```

--- a/docs/07-tables.md
+++ b/docs/07-tables.md
@@ -1,0 +1,79 @@
+# Tables
+
+`InitPHP\Console\Utils\Table` renders styleable ASCII/ANSI tables. Rows are associative arrays; the union of their keys forms the header, columns are auto-sized, and styles are emitted as SGR escape sequences.
+
+## Basic usage
+
+```php
+use InitPHP\Console\Utils\Table;
+
+$table = Table::create();
+
+$table->row(['id' => 1, 'name' => 'Matthew S.', 'email' => 'matthew@example.com'])
+      ->row(['id' => 2, 'name' => 'Millie J.',  'email' => 'millie@example.com']);
+
+echo $table;             // uses __toString()
+// or
+echo $table->getContent();
+```
+
+```
+╔══════╤══════════════╤══════════════════════════╗
+║ id   │ name         │ email                    ║
+╟──────┼──────────────┼──────────────────────────╢
+║ 1    │ Matthew S.   │ matthew@example.com      ║
+║ 2    │ Millie J.    │ millie@example.com       ║
+╚══════╧══════════════╧══════════════════════════╝
+```
+
+`Table::create()` is a convenience factory equivalent to `new Table()`; both return a fresh instance and every mutator returns `$this` for chaining.
+
+## Styling
+
+All four style setters take one or more SGR codes (the same constants as [`Output`](05-output.md), also exposed on `Table`):
+
+```php
+$table = Table::create()
+    ->setHeaderStyle(Table::COLOR_RED, Table::BOLD)  // header row
+    ->setCellStyle(Table::COLOR_GREEN)               // every body cell
+    ->setBorderStyle(Table::COLOR_BLUE)              // the frame
+    ->setColumnCellStyle('status', Table::COLOR_YELLOW); // one column's body cells
+```
+
+- `setHeaderStyle()` — defaults to `[BOLD]`.
+- `setCellStyle()` — applied to all body cells.
+- `setBorderStyle()` — applied to the box-drawing characters.
+- `setColumnCellStyle($column, ...)` — overrides body styling for a single column.
+
+## How values are rendered
+
+Non-string cell values are converted to a printable form:
+
+| Value type                         | Rendered as          |
+|------------------------------------|----------------------|
+| `null`                             | `[NULL]`             |
+| `true` / `false`                   | `[TRUE]` / `[FALSE]` |
+| array                              | `[ARRAY]`            |
+| array that is callable             | `[CALLABLE]`         |
+| other callable                     | `[CALLABLE]`         |
+| resource                           | `[RESOURCE]`         |
+| object                             | its class name       |
+| int / float                        | string cast          |
+
+Rows with different key sets are allowed: any cell missing from a row is rendered as `[NULL]`.
+
+```php
+Table::create()
+    ->row(['id' => 1, 'name' => 'Ada', 'active' => true])
+    ->row(['id' => 2, 'name' => null,  'meta' => ['x' => 1]])
+    ->getContent();
+// missing/extra columns are filled with [NULL]; null → [NULL]; array → [ARRAY]
+```
+
+## Multibyte text
+
+Column widths are measured with `mb_strlen()` when the `mbstring` extension is available, so UTF-8 values such as `İstanbul` or `Mühammet` align correctly. Without `mbstring` the renderer falls back to `strlen()`.
+
+## Legacy alias
+
+This class was previously shipped as `initphp/cli-table`. The old fully-qualified name `\InitPHP\CLITable\Table` still resolves to it via a `class_alias`, so existing code keeps working. See [Migrating from `initphp/cli-table`](08-migrating-from-cli-table.md).

--- a/docs/08-migrating-from-cli-table.md
+++ b/docs/08-migrating-from-cli-table.md
@@ -1,0 +1,59 @@
+# Migrating from `initphp/cli-table`
+
+The standalone [`initphp/cli-table`](https://github.com/InitPHP/CLITable) package was merged into `initphp/console` as of **2.1** and is now deprecated. The table renderer now lives at `InitPHP\Console\Utils\Table`.
+
+## What you need to do
+
+### 1. Switch the dependency
+
+```diff
+  "require": {
+-     "initphp/cli-table": "^1.0",
++     "initphp/console": "^2.1"
+  }
+```
+
+```bash
+composer update initphp/console
+```
+
+`initphp/console` declares a Composer `replace` for `initphp/cli-table`, so Composer will never install both packages side by side — even if a transitive dependency still asks for the old one.
+
+### 2. (Optional) update your imports
+
+**No code change is strictly required.** This package registers a `class_alias` so the legacy fully-qualified name keeps working:
+
+```php
+use InitPHP\CLITable\Table; // still resolves — backed by the alias
+```
+
+When you next touch the code, prefer the canonical namespace:
+
+```php
+// Before
+use InitPHP\CLITable\Table;
+
+// After
+use InitPHP\Console\Utils\Table;
+```
+
+The public API (`create()`, `row()`, `setHeaderStyle()`, `setCellStyle()`, `setBorderStyle()`, `setColumnCellStyle()`, `getContent()`, `__toString()`) is unchanged — see [Tables](07-tables.md).
+
+## How the alias works
+
+`src/aliases.php` (loaded automatically via Composer's `files` autoloading) runs:
+
+```php
+if (!class_exists(\InitPHP\CLITable\Table::class, false)) {
+    class_alias(
+        \InitPHP\Console\Utils\Table::class,
+        'InitPHP\\CLITable\\Table'
+    );
+}
+```
+
+The `class_exists(..., false)` check (autoload disabled) is a safety net: if the legacy class were somehow already loaded, the alias is skipped to avoid a "cannot redeclare class" fatal. In normal use the `replace` directive guarantees the legacy class is absent, so the alias is always created.
+
+## Deprecation timeline
+
+The alias is a **transition aid**. Treat the legacy `InitPHP\CLITable\Table` name as deprecated and migrate to `InitPHP\Console\Utils\Table` at your convenience; the alias may be removed in a future major release.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset name="InitPHP Console">
+    <description>PSR-12 baseline for InitPHP/Console.</description>
+
+    <file>src</file>
+    <file>tests</file>
+
+    <arg name="basepath" value="."/>
+    <arg name="colors"/>
+    <arg name="parallel" value="4"/>
+    <arg value="np"/>
+
+    <rule ref="PSR12"/>
+
+    <config name="php_version" value="70200"/>
+</ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+    level: 6
+    paths:
+        - src
+    excludePaths:
+        # Runtime BC shim that intentionally references the (now absent) legacy class.
+        - src/aliases.php
+    treatPhpDocTypesAsCertain: false
+    reportUnmatchedIgnoredErrors: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Application.php
+++ b/src/Application.php
@@ -83,7 +83,7 @@ class Application
      * @param string      $version     Application version string.
      * @param Output|null $output      Output implementation; a default {@see Output} is created when null.
      */
-    public function __construct(string $application = 'InitPHP Console Application', string $version = self::VERSION, Output $output = null)
+    public function __construct(string $application = 'InitPHP Console Application', string $version = self::VERSION, ?Output $output = null)
     {
         $this->application = $application;
         $this->version = $version;
@@ -144,7 +144,7 @@ class Application
      * @param array<int, string>|null $argv Tokens to dispatch; defaults to the global `$argv`.
      * @return bool `true` when a command (or help) ran, `false` when nothing matched or no command was given.
      */
-    public function run(array $argv = null): bool
+    public function run(?array $argv = null): bool
     {
         if ($argv === null) {
             $argv = \is_array($GLOBALS['argv'] ?? null) ? $GLOBALS['argv'] : [];

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,65 +1,122 @@
 <?php
+
 /**
  * Application.php
  *
- * This file is part of Console.
+ * This file is part of InitPHP Console.
  *
  * @author     Muhammet ŞAFAK <info@muhammetsafak.com.tr>
  * @copyright  Copyright © 2022 Muhammet ŞAFAK
- * @license    ./LICENSE  MIT
- * @version    2.0
+ * @license    https://github.com/InitPHP/Console/blob/main/LICENSE  MIT
  * @link       https://www.muhammetsafak.com.tr
  */
 
 declare(strict_types=1);
+
 namespace InitPHP\Console;
 
+/**
+ * The console application: a registry of commands and the dispatcher that maps
+ * a command-line invocation onto the matching command.
+ *
+ * Commands may be registered either as closures or as classes extending
+ * {@see Command}. The built-in `help`/`list` command renders an overview, and
+ * `<command> --help` renders per-command usage.
+ */
 class Application
 {
-    public const VERSION = '2.0';
+    public const VERSION = '2.1.0';
 
-    /** @var string */
+    /**
+     * Human-readable application name shown in help output.
+     *
+     * @var string
+     */
     protected $application;
 
-    /** @var string */
+    /**
+     * Application version shown in help output.
+     *
+     * @var string
+     */
     protected $version;
 
+    /**
+     * The script name (`$argv[0]`) captured during {@see run()}.
+     *
+     * @var string
+     */
     protected $terminal;
 
-    /** @var array */
+    /**
+     * Registered commands keyed by command name.
+     *
+     * @var array<string, array{command: string, execute: callable|Command, definition: string, help: string}>
+     */
     protected $commands = [];
 
+    /**
+     * @var InputInterface|null
+     */
     protected $input;
 
+    /**
+     * The output implementation.
+     *
+     * Typed as the concrete {@see Output} because {@see Command::execute()} and
+     * {@see InputArgument::run()} require it; {@see Output} implements
+     * {@see OutputInterface} so consumers may still program to the interface.
+     *
+     * @var Output|null
+     */
     protected $output;
 
+    /**
+     * The command name resolved during {@see run()}.
+     *
+     * @var string|null
+     */
     protected $command;
 
-    public function __construct(string $application = 'InitPHP Console Application', string $version = '2.0')
+    /**
+     * @param string      $application Human-readable application name.
+     * @param string      $version     Application version string.
+     * @param Output|null $output      Output implementation; a default {@see Output} is created when null.
+     */
+    public function __construct(string $application = 'InitPHP Console Application', string $version = self::VERSION, Output $output = null)
     {
         $this->application = $application;
         $this->version = $version;
+        $this->output = $output;
     }
 
     /**
-     * @param string $command
-     * @param callable|null $execute
-     * @param string $definition
+     * Registers a command.
+     *
+     * When `$execute` is null, `$command` is treated as the fully-qualified
+     * name of a {@see Command} subclass which is instantiated; its
+     * {@see Command::$command}, {@see Command::definition()} and
+     * {@see Command::help()} are read from the instance.
+     *
+     * @param string        $command    Command name, or a {@see Command} class name when `$execute` is null.
+     * @param callable|null $execute    Handler invoked with `(Input, Output)`.
+     * @param string        $definition Short description for the command listing.
      * @return $this
-     * @throws \InvalidArgumentException
+     * @throws \InvalidArgumentException When the handler does not meet the requirements.
+     * @throws \LogicException When a {@see Command} class does not declare its command name.
      */
-    public function register(string $command, callable $execute = null, string $definition = ''): self
+    public function register(string $command, ?callable $execute = null, string $definition = ''): self
     {
         if ($execute === null) {
             if (!\class_exists($command)) {
-                throw new \InvalidArgumentException("The specified executable does not meet the requirements.");
+                throw new \InvalidArgumentException('The specified executable does not meet the requirements.');
             }
             $commandObj = new $command();
             if (!($commandObj instanceof Command)) {
-                throw new \InvalidArgumentException("The specified executable does not meet the requirements.");
+                throw new \InvalidArgumentException('The specified executable does not meet the requirements.');
             }
-            if (!isset($commandObj->command)) {
-                throw new \Exception('The Command feature of the command class is undefined.');
+            if (empty($commandObj->command)) {
+                throw new \LogicException('The command name of the command class is undefined.');
             }
             $command = $commandObj->command;
             $execute = $commandObj;
@@ -71,97 +128,98 @@ class Application
         } else {
             $help = $definition;
         }
-        if (!\is_callable($execute) && !($execute instanceof Command)) {
-            throw new \InvalidArgumentException("The specified executable does not meet the requirements.");
-        }
         $this->commands[$command] = [
-            'command'           => $command,
-            'execute'           => $execute,
-            'definition'        => $definition,
-            'help'              => $help,
+            'command'    => $command,
+            'execute'    => $execute,
+            'definition' => $definition,
+            'help'       => $help,
         ];
 
         return $this;
     }
 
-    public function run(): bool
+    /**
+     * Parses the command line and dispatches the matching command.
+     *
+     * @param array<int, string>|null $argv Tokens to dispatch; defaults to the global `$argv`.
+     * @return bool `true` when a command (or help) ran, `false` when nothing matched or no command was given.
+     */
+    public function run(array $argv = null): bool
     {
-        global $argv;
+        if ($argv === null) {
+            $argv = \is_array($GLOBALS['argv'] ?? null) ? $GLOBALS['argv'] : [];
+        }
 
-        $inputs = $argv;
-        $this->terminal = $inputs[0];
-        \array_shift($inputs);
-        if (empty($inputs)) {
+        $this->terminal = (string)($argv[0] ?? '');
+        \array_shift($argv);
+        if (empty($argv)) {
             return false;
         }
 
-        $this->command = \current($inputs);
-        \array_shift($inputs);
+        $this->command = (string)\current($argv);
+        \array_shift($argv);
 
-        $this->input = new Input($inputs);
-        $this->output = new Output();
+        $this->input = new Input($argv);
+        $output = $this->output ?? ($this->output = new Output());
 
-        if (in_array($this->command, ['help', 'list'])) {
-            $this->help($this->input, $this->output);
+        if (\in_array($this->command, ['help', 'list'], true)) {
+            $this->help($this->input, $output);
             return true;
         }
 
-        if (isset($this->commands[$this->command])) {
+        if (!isset($this->commands[$this->command])) {
+            $output->error('The command was not found.');
+            return true;
+        }
 
-            try {
-                $command = $this->commands[$this->command];
+        try {
+            $command = $this->commands[$this->command];
 
-                if ($this->input->hasArgument('help')) {
-                    $this->commandHelp($this->input, $this->output, $command);
-                    return true;
-                }
-                $execute = $command['execute'];
+            if ($this->input->hasArgument('help')) {
+                $this->commandHelp($this->input, $output, $command);
+                return true;
+            }
+            $execute = $command['execute'];
 
-                if (\is_callable($execute)) {
-                    \call_user_func_array($execute, [$this->input, $this->output]);
-                    return true;
-                }
-
-                if ($execute instanceof Command) {
-                    $arguments = $execute->arguments();
-                    if (!empty($arguments)) {
-                        foreach ($arguments as $argument) {
-                            if ($argument instanceof InputArgument) {
-                                if ($argument->run($this->input, $this->output) === FALSE) {
-                                    return false;
-                                }
-                            } else {
-                                $this->output->error("One or more arguments are wrong! Please check that you create arguments from the InputArgument object.");
-                            }
-                        }
+            if ($execute instanceof Command) {
+                foreach ($execute->arguments() as $argument) {
+                    if (!($argument instanceof InputArgument)) {
+                        $output->error('One or more arguments are wrong! Please check that you create arguments from the InputArgument object.');
+                        return false;
                     }
-
-                    $execute->execute($this->input, $this->output);
-                    return true;
+                    if ($argument->run($this->input, $output) === false) {
+                        return false;
+                    }
                 }
 
-
-                $this->output->error("The command is not executable; Please make sure the command is correctly recorded.");
-                return false;
-            } catch (\Throwable $e) {
-                $this->output->error($e->getMessage());
-                return false;
+                $execute->execute($this->input, $output);
+                return true;
             }
 
-        } else {
-            $this->output->error("The command was not found.");
+            if (\is_callable($execute)) {
+                \call_user_func_array($execute, [$this->input, $output]);
+                return true;
+            }
+
+            $output->error('The command is not executable; Please make sure the command is correctly recorded.');
+            return false;
+        } catch (\Throwable $e) {
+            $output->error($e->getMessage());
+            return false;
         }
-        return true;
     }
 
-    private function help(Input $input, Output $output)
+    /**
+     * Renders the application banner and the grouped command listing.
+     */
+    private function help(InputInterface $input, OutputInterface $output): void
     {
         $output->writeln('
-    ____      _ __  ____  __  ______     ______                       __    ___    ____ 
+    ____      _ __  ____  __  ______     ______                       __    ___    ____
    /  _/___  (_) /_/ __ \/ / / / __ \   / ____/___  ____  _________  / /__ |__ \  / __ \
    / // __ \/ / __/ /_/ / /_/ / /_/ /  / /   / __ \/ __ \/ ___/ __ \/ / _ \__/ / / / / /
- _/ // / / / / /_/ ____/ __  / ____/  / /___/ /_/ / / / (__  ) /_/ / /  __/ __/_/ /_/ / 
-/___/_/ /_/_/\__/_/   /_/ /_/_/       \____/\____/_/ /_/____/\____/_/\___/____(_)____/  
+ _/ // / / / / /_/ ____/ __  / ____/  / /___/ /_/ / / / (__  ) /_/ / /  __/ __/_/ /_/ /
+/___/_/ /_/_/\__/_/   /_/ /_/_/       \____/\____/_/ /_/____/\____/_/\___/____(_)____/
 
         ');
         $output->writeln($this->application . ' v' . $this->version);
@@ -169,66 +227,76 @@ class Application
         $groups = [];
         $ungroup = [];
         foreach ($this->commands as $command) {
-            if (\strpos($command['command'], ':') === FALSE) {
-                $ungroup[$command['command']] = !empty($command['definition']) ? $command['definition'] : $command['help'];
+            $description = !empty($command['definition']) ? $command['definition'] : $command['help'];
+            if (\strpos($command['command'], ':') === false) {
+                $ungroup[$command['command']] = $description;
                 continue;
             }
             $split = \explode(':', $command['command'], 2);
             if (!isset($groups[$split[0]])) {
                 $groups[$split[0]] = [];
             }
-            $groups[$split[0]][$command['command']] = !empty($command['definition']) ? $command['definition'] : $command['help'];
+            $groups[$split[0]][$command['command']] = $description;
         }
 
         $output->writeln('');
         $output->writeln('[COMMANDS]', [], [Output::COLOR_RED, Output::BOLD]);
-        foreach ($groups as $group_name => $group) {
+        foreach ($groups as $groupName => $group) {
             $output->writeln('');
-            $output->writeln($group_name, [], [Output::COLOR_MAGENTA]);
+            $output->writeln($groupName, [], [Output::COLOR_MAGENTA]);
             $output->list($group, 1);
         }
         $output->writeln('');
         $output->list($ungroup);
         $output->writeln('');
 
-        $output->writeln('Copyright © 2022 - ' . date("Y") . ' InitPHP Console ' . self::VERSION);
-        $output->writeln('http://initphp.org - https://github.com/InitPHP/Console');
+        $output->writeln('Copyright © 2022 - ' . \date('Y') . ' InitPHP Console ' . self::VERSION);
+        $output->writeln('https://initphp.github.io - https://github.com/InitPHP/Console');
     }
 
-    private function commandHelp(Input $input, Output $output, array $command)
+    /**
+     * Renders the usage and parameter list for a single command.
+     *
+     * @param array{command: string, execute: callable|Command, definition: string, help: string} $command
+     */
+    private function commandHelp(InputInterface $input, OutputInterface $output, array $command): void
     {
-        $output->writeln(\PHP_EOL . ($command['help'] ?? $command['definition']));
+        $output->writeln(\PHP_EOL . ($command['help'] !== '' ? $command['help'] : $command['definition']));
         $exe = $command['execute'];
-        if ($exe instanceof Command) {
-            $usageArguments = ['optional' => [], 'required' => []];
-            if ($arguments = $exe->arguments()) {
-                $rows = [];
-                foreach ($arguments as $argument) {
-                    if (!($argument instanceof InputArgument)) {
-                        $output->error("One or more arguments are wrong! Please check that you create arguments from the InputArgument object.");
-                        exit;
-                    }
-                    $rows[$argument->getName()] = $argument->getDefinition();
-                    if ($argument->isOptional()) {
-                        $usageArguments['optional'][] = '[' . \trim($argument->getName() . '=(' . $argument->getType() . ')' . $argument->getDefault()) . ']';
-                    } else {
-                        $usageArguments['required'][] = \trim($argument->getName() . '=(' . $argument->getType() . ')'.$argument->getDefault());
-                    }
-                }
-                $output->writeln(\PHP_EOL . "[PARAMETERS]");
-                $output->list($rows, 1);
-            }
-            $usage = "[USAGE]" . \PHP_EOL . "\t";
-            $usage .= 'php '
-                . $this->terminal
-                . ' '
-                . $exe->command
-                . ' '
-                . \implode(' ', $usageArguments['required'])
-                . ' '
-                . \implode(' ', $usageArguments['optional']);
-            $output->writeln(\trim($usage));
+        if (!($exe instanceof Command)) {
+            return;
         }
-    }
 
+        $usageArguments = ['optional' => [], 'required' => []];
+        $arguments = $exe->arguments();
+        if (!empty($arguments)) {
+            $rows = [];
+            foreach ($arguments as $argument) {
+                if (!($argument instanceof InputArgument)) {
+                    $output->error('One or more arguments are wrong! Please check that you create arguments from the InputArgument object.');
+                    return;
+                }
+                $rows[$argument->getName()] = $argument->getDefinition();
+                $usage = \trim($argument->getName() . '=(' . $argument->getType() . ')' . $argument->getDefault());
+                if ($argument->isOptional()) {
+                    $usageArguments['optional'][] = '[' . $usage . ']';
+                } else {
+                    $usageArguments['required'][] = $usage;
+                }
+            }
+            $output->writeln(\PHP_EOL . '[PARAMETERS]');
+            $output->list($rows, 1);
+        }
+
+        $usage = '[USAGE]' . \PHP_EOL . "\t"
+            . 'php '
+            . $this->terminal
+            . ' '
+            . $exe->command
+            . ' '
+            . \implode(' ', $usageArguments['required'])
+            . ' '
+            . \implode(' ', $usageArguments['optional']);
+        $output->writeln(\trim($usage));
+    }
 }

--- a/src/Command.php
+++ b/src/Command.php
@@ -1,13 +1,13 @@
 <?php
+
 /**
  * Command.php
  *
- * This file is part of Console.
+ * This file is part of InitPHP Console.
  *
  * @author     Muhammet ŞAFAK <info@muhammetsafak.com.tr>
  * @copyright  Copyright © 2022 Muhammet ŞAFAK
- * @license    ./LICENSE  MIT
- * @version    2.0
+ * @license    https://github.com/InitPHP/Console/blob/main/LICENSE  MIT
  * @link       https://www.muhammetsafak.com.tr
  */
 
@@ -15,27 +15,56 @@ declare(strict_types=1);
 
 namespace InitPHP\Console;
 
+/**
+ * Base class for class-based commands.
+ *
+ * Subclasses must set {@see $command} to the name the command is invoked by
+ * and implement {@see execute()}. The remaining hooks ({@see help()},
+ * {@see definition()}, {@see arguments()}) are optional and may be overridden
+ * to enrich the generated help output and to declare typed arguments.
+ */
 abstract class Command
 {
-
-    /** @var string */
+    /**
+     * The name the command is registered and invoked under (e.g. `make:model`).
+     *
+     * @var string
+     */
     public $command;
 
+    /**
+     * Runs the command.
+     *
+     * Invoked by {@see Application::run()} after every declared
+     * {@see arguments()} entry has been validated.
+     *
+     * @return mixed
+     */
     abstract public function execute(Input $input, Output $output);
 
+    /**
+     * Long help text shown by `<command> --help`.
+     */
     public function help(): string
     {
         return 'No explanation for this command is specified.';
     }
 
+    /**
+     * Short one-line description shown in the command listing.
+     */
     public function definition(): string
     {
         return '';
     }
 
+    /**
+     * The typed arguments this command accepts.
+     *
+     * @return array<int, InputArgument>
+     */
     public function arguments(): array
     {
         return [];
     }
-
 }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1,13 +1,13 @@
 <?php
+
 /**
  * Helpers.php
  *
- * This file is part of Console.
+ * This file is part of InitPHP Console.
  *
  * @author     Muhammet ŞAFAK <info@muhammetsafak.com.tr>
  * @copyright  Copyright © 2022 Muhammet ŞAFAK
- * @license    ./LICENSE  MIT
- * @version    2.0
+ * @license    https://github.com/InitPHP/Console/blob/main/LICENSE  MIT
  * @link       https://www.muhammetsafak.com.tr
  */
 
@@ -15,9 +15,28 @@ declare(strict_types=1);
 
 namespace InitPHP\Console;
 
+/**
+ * Small, stateless value helpers shared across the console components.
+ */
 final class Helpers
 {
-
+    /**
+     * Casts a raw string token coming from the command line into the most
+     * appropriate PHP scalar type.
+     *
+     * The following conversions are applied (case-insensitive):
+     *
+     * - `""`            → `""` (empty string)
+     * - `"null"`        → `null`
+     * - `"true"`/`"yes"`→ `true`
+     * - `"false"`/`"no"`→ `false`
+     * - an integer-like token (optionally signed) → `int`
+     * - a decimal token using `.` or `,` as separator → `float`
+     * - anything else is returned unchanged as a `string`
+     *
+     * @param string $value Raw token to cast.
+     * @return string|int|float|bool|null
+     */
     public static function strValueCast(string $value)
     {
         switch (\strtolower($value)) {
@@ -32,14 +51,13 @@ final class Helpers
             case 'false':
                 return false;
             default:
-                if ((bool)\preg_match('/^[-|+]*[0-9]+$/', $value)) {
+                if (\preg_match('/^[-+]?[0-9]+$/', $value) === 1) {
                     return \intval($value);
                 }
-                if ((bool)\preg_match('/^[-|+]*[0-9]+[\.|,]{1}[0-9]+$/', $value)) {
-                    return \floatval(\strtr($value, [','=>'.']));
+                if (\preg_match('/^[-+]?[0-9]+[.,][0-9]+$/', $value) === 1) {
+                    return \floatval(\strtr($value, [',' => '.']));
                 }
                 return $value;
         }
     }
-
 }

--- a/src/Input.php
+++ b/src/Input.php
@@ -1,13 +1,13 @@
 <?php
+
 /**
  * Input.php
  *
- * This file is part of Console.
+ * This file is part of InitPHP Console.
  *
  * @author     Muhammet ŞAFAK <info@muhammetsafak.com.tr>
  * @copyright  Copyright © 2022 Muhammet ŞAFAK
- * @license    ./LICENSE  MIT
- * @version    2.0
+ * @license    https://github.com/InitPHP/Console/blob/main/LICENSE  MIT
  * @link       https://www.muhammetsafak.com.tr
  */
 
@@ -15,53 +15,153 @@ declare(strict_types=1);
 
 namespace InitPHP\Console;
 
-class Input
+/**
+ * Parses and exposes the raw command-line tokens that follow the command name.
+ *
+ * @see InputInterface for the semantics of arguments, options and segments.
+ */
+class Input implements InputInterface
 {
-
+    /**
+     * The raw tokens this instance was constructed from.
+     *
+     * @var array<int, string>
+     */
     protected $argv;
 
+    /**
+     * Parsed `--name(=value)` arguments.
+     *
+     * @var array<string, mixed>
+     */
     protected $arguments = [];
 
+    /**
+     * Parsed `-name(=value)` options.
+     *
+     * @var array<string, mixed>
+     */
     protected $options = [];
 
+    /**
+     * Parsed bare positional tokens.
+     *
+     * @var array<int, mixed>
+     */
     protected $segments = [];
 
+    /**
+     * @param array<int, string> $argv Tokens that follow the command name.
+     */
     public function __construct(array $argv)
     {
         $this->argv = $argv;
-        for ($i = 0; $i < \count($this->argv); ++$i) {
-            if (!isset($this->argv[$i])) {
+        $this->parse($argv);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasArgument(string $name): bool
+    {
+        return \array_key_exists($name, $this->arguments);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getArgument(string $name, $default = null)
+    {
+        return \array_key_exists($name, $this->arguments) ? $this->arguments[$name] : $default;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function allArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasSegment(int $index): bool
+    {
+        return \array_key_exists($index, $this->segments);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSegment(int $index, $default = null)
+    {
+        return \array_key_exists($index, $this->segments) ? $this->segments[$index] : $default;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function allSegment(): array
+    {
+        return $this->segments;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasOption(string $name): bool
+    {
+        return \array_key_exists($name, $this->options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOption(string $name, $default = null)
+    {
+        return \array_key_exists($name, $this->options) ? $this->options[$name] : $default;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function allOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function importArguments(array ...$arguments): void
+    {
+        $this->arguments = \array_merge($this->arguments, ...$arguments);
+    }
+
+    /**
+     * Splits the raw tokens into arguments, options and segments.
+     *
+     * @param array<int, string> $argv
+     */
+    private function parse(array $argv): void
+    {
+        foreach ($argv as $segment) {
+            if (!\is_string($segment)) {
                 continue;
             }
-            $segment = $this->argv[$i];
+            // A token made up solely of whitespace and/or dashes (e.g. "--") carries no data.
             if (\trim($segment, " \t\n\r\0\x0B-") === '') {
                 continue;
             }
-            if (\substr($segment, 0, 2) == '--') {
-                /** ARGUMENTS */
-                $seg = \ltrim($segment, '-');
-                if (\strpos($seg, '=') !== FALSE) {
-                    $split = \explode('=', $seg, 2);
-                    $this->arguments[$split[0]] = Helpers::strValueCast($split[1]);
-                } else {
-                    $this->arguments[$seg] = '';
-                }
+
+            if (\strpos($segment, '--') === 0) {
+                $this->parseArgument(\ltrim($segment, '-'));
                 continue;
             }
 
-            if (\substr($segment, 0, 1) == '-') {
-                /** OPTIONS */
-                $seg = \ltrim($segment, '-');
-                if (\strpos($seg, '=') === FALSE) {
-                    !isset($this->options[$seg]) && $this->options[$seg] = '';
-                    $options = \preg_split('//', $seg, -1, \PREG_SPLIT_NO_EMPTY);
-                    foreach ($options as $option) {
-                        $this->options[$option] = $option;
-                    }
-                } else {
-                    $split = \explode('=', $seg, 2);
-                    $this->options[$split[0]] = Helpers::strValueCast($split[1]);
-                }
+            if (\strpos($segment, '-') === 0) {
+                $this->parseOption(\ltrim($segment, '-'));
                 continue;
             }
 
@@ -70,81 +170,36 @@ class Input
     }
 
     /**
-     * @param string $name
-     * @return bool
+     * Stores a single `--name` or `--name=value` argument.
      */
-    public function hasArgument(string $name): bool
+    private function parseArgument(string $token): void
     {
-        return \array_key_exists($name, $this->arguments);
+        if (\strpos($token, '=') !== false) {
+            [$name, $value] = \explode('=', $token, 2);
+            $this->arguments[$name] = Helpers::strValueCast($value);
+            return;
+        }
+        $this->arguments[$token] = '';
     }
 
     /**
-     * @param string $name
-     * @param mixed $default
-     * @return mixed|null
+     * Stores a `-name=value` option, or one/more combined boolean short flags.
+     *
+     * `-f`   →  `['f' => 'f']`
+     * `-abc` →  `['a' => 'a', 'b' => 'b', 'c' => 'c']`
+     * `-k=v` →  `['k' => 'v']`
      */
-    public function getArgument(string $name, $default = null)
+    private function parseOption(string $token): void
     {
-        return \array_key_exists($name, $this->arguments) ? $this->arguments[$name] : $default;
-    }
+        if (\strpos($token, '=') !== false) {
+            [$name, $value] = \explode('=', $token, 2);
+            $this->options[$name] = Helpers::strValueCast($value);
+            return;
+        }
 
-    /**
-     * @return array
-     */
-    public function allArguments(): array
-    {
-        return $this->arguments;
+        $flags = \preg_split('//', $token, -1, \PREG_SPLIT_NO_EMPTY);
+        foreach (($flags ?: []) as $flag) {
+            $this->options[$flag] = $flag;
+        }
     }
-
-    /**
-     * @param int $index
-     * @return bool
-     */
-    public function hasSegment(int $index): bool
-    {
-        return \array_key_exists($index, $this->segments);
-    }
-
-    /**
-     * @param int $index
-     * @param mixed $default
-     * @return mixed
-     */
-    public function getSegment(int $index, $default = null)
-    {
-        return \array_key_exists($index, $this->segments) ? $this->segments[$index] : $default;
-    }
-
-    /**
-     * @return array
-     */
-    public function allSegment(): array
-    {
-        return $this->segments;
-    }
-
-    /**
-     * @param string $name
-     * @return bool
-     */
-    public function hasOption(string $name): bool
-    {
-        return array_key_exists($name, $this->options);
-    }
-
-    /**
-     * @param string $name
-     * @param $default
-     * @return mixed|null
-     */
-    public function getOption(string $name, $default = null)
-    {
-        return \array_key_exists($name, $this->options) ? $this->options[$name] : $default;
-    }
-
-    public function importArguments(array ...$arguments)
-    {
-        $this->arguments = \array_merge($this->arguments, ...$arguments);
-    }
-
 }

--- a/src/InputArgument.php
+++ b/src/InputArgument.php
@@ -1,13 +1,13 @@
 <?php
+
 /**
  * InputArgument.php
  *
- * This file is part of Console.
+ * This file is part of InitPHP Console.
  *
  * @author     Muhammet ŞAFAK <info@muhammetsafak.com.tr>
  * @copyright  Copyright © 2022 Muhammet ŞAFAK
- * @license    ./LICENSE  MIT
- * @version    2.0
+ * @license    https://github.com/InitPHP/Console/blob/main/LICENSE  MIT
  * @link       https://www.muhammetsafak.com.tr
  */
 
@@ -15,35 +15,81 @@ declare(strict_types=1);
 
 namespace InitPHP\Console;
 
+/**
+ * Declares a typed `--name` argument for a {@see Command}: its accepted type,
+ * default value, whether it is required and a human-readable definition.
+ *
+ * During dispatch {@see run()} validates the value supplied on the command
+ * line (falling back to the default when appropriate) and writes the resolved
+ * value back into the {@see Input} bag.
+ */
 final class InputArgument
 {
-
+    /** Accepts any value. */
     public const ANY = 'ANY';
+
+    /** Accepts an integer. */
     public const INT = 'INT';
+
+    /** Accepts a float. */
     public const FLOAT = 'FLOAT';
+
+    /** Accepts any numeric value (int, float or numeric string). */
     public const NUMERIC = 'NUMBER';
+
+    /** Accepts a boolean (`true`/`false`, or `1`/`0`). */
     public const BOOL = 'BOOL';
+
+    /** Accepts a string (numeric and boolean values are stringified). */
     public const STR = 'STRING';
 
+    /**
+     * The set of types accepted by the constructor.
+     *
+     * @var array<int, string>
+     */
     protected const SUPPORTED_TYPES = [
         self::ANY, self::INT, self::FLOAT, self::NUMERIC, self::BOOL, self::STR,
     ];
 
+    /**
+     * @var string
+     */
     protected $name;
 
+    /**
+     * @var string
+     */
     protected $definition;
 
-    protected $isOptional = true;
+    /**
+     * @var bool
+     */
+    protected $isOptional;
 
+    /**
+     * @var mixed
+     */
     protected $default;
 
+    /**
+     * @var string
+     */
     protected $type;
 
+    /**
+     * @param string $name       Argument name without the leading dashes.
+     * @param string $type       One of the `self::*` type constants.
+     * @param mixed  $default    Default value; must satisfy `$type`.
+     * @param bool   $isOptional Whether the argument may be omitted.
+     * @param string $definition Human-readable description shown in help output.
+     * @throws \InvalidArgumentException When `$type` is unsupported or `$default` does not satisfy it.
+     */
     public function __construct(string $name, $type, $default, bool $isOptional = true, string $definition = '')
     {
         $this->name = $name;
         if (!\in_array($type, self::SUPPORTED_TYPES, true)) {
-            throw new \InvalidArgumentException('The species defined for the --' . $this->name . ' parameter is not supported.');
+            throw new \InvalidArgumentException('The type defined for the --' . $this->name . ' parameter is not supported.');
         }
         $this->type = $type;
         if (!$this->valueCheck($default)) {
@@ -54,63 +100,89 @@ final class InputArgument
         $this->definition = $definition;
     }
 
+    /**
+     * Whether the argument may be omitted from the command line.
+     */
     public function isOptional(): bool
     {
         return $this->isOptional;
     }
 
+    /**
+     * The declared type, one of the `self::*` type constants.
+     */
     public function getType(): string
     {
         return $this->type;
     }
 
+    /**
+     * The argument name, prefixed with `--`.
+     */
     public function getName(): string
     {
         return '--' . $this->name;
     }
 
+    /**
+     * The human-readable description.
+     */
     public function getDefinition(): string
     {
         return $this->definition;
     }
 
+    /**
+     * The default value rendered as a string, or `null` when there is none.
+     */
     public function getDefault(): ?string
     {
         return isset($this->default) ? (string)$this->default : null;
     }
 
-    public function run(Input &$input, Output &$output): bool
+    /**
+     * Resolves and validates this argument against the parsed input.
+     *
+     * The value is looked up as an argument first, then as an option. When it
+     * is missing or invalid the default is used for optional arguments; for
+     * required arguments an error is written and `false` is returned. The
+     * resolved value is written back into `$input`.
+     *
+     * @return bool `false` when a required argument is missing or invalid.
+     */
+    public function run(Input $input, Output $output): bool
     {
         if ($input->hasArgument($this->name)) {
             $value = $input->getArgument($this->name);
         } elseif ($input->hasOption($this->name)) {
             $value = $input->getOption($this->name);
+        } elseif ($this->isOptional === false) {
+            $output->error('The --' . $this->name . ' parameter is undefined.');
+            return false;
         } else {
-            if ($this->isOptional === FALSE) {
-                $output->error('The --' . $this->name . ' parameter is undefined.');
-                return false;
-            } else {
-                $input->importArguments([$this->name => $this->default]);
-                return true;
-            }
+            $input->importArguments([$this->name => $this->default]);
+            return true;
         }
 
         if (!$this->valueCheck($value)) {
-            if ($this->isOptional === FALSE) {
+            if ($this->isOptional === false) {
                 $output->error('The value given for the --' . $this->name . ' parameter is invalid.');
                 return false;
-            } else {
-                $value = $this->default;
             }
-        } else {
-            if (empty($value) && $this->isOptional === FALSE && isset($this->default)) {
-                $value = $this->default;
-            }
+            $value = $this->default;
+        } elseif (($value === '' || $value === null) && $this->isOptional === false && isset($this->default)) {
+            $value = $this->default;
         }
+
         $input->importArguments([$this->name => $value]);
         return true;
     }
 
+    /**
+     * Validates (and, for some types, coerces) a value against the declared type.
+     *
+     * @param mixed $value Passed by reference so coercible values can be normalised.
+     */
     private function valueCheck(&$value): bool
     {
         if ($this->type === self::ANY) {
@@ -120,7 +192,7 @@ final class InputArgument
             if (\is_bool($value)) {
                 return true;
             }
-            if (\in_array($value, [0, 1])) {
+            if (\in_array($value, [0, 1], true)) {
                 $value = (bool)$value;
                 return true;
             }
@@ -143,6 +215,4 @@ final class InputArgument
         }
         return false;
     }
-
-
 }

--- a/src/InputInterface.php
+++ b/src/InputInterface.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * InputInterface.php
+ *
+ * This file is part of InitPHP Console.
+ *
+ * @author     Muhammet ŞAFAK <info@muhammetsafak.com.tr>
+ * @copyright  Copyright © 2022 Muhammet ŞAFAK
+ * @license    https://github.com/InitPHP/Console/blob/main/LICENSE  MIT
+ * @link       https://www.muhammetsafak.com.tr
+ */
+
+declare(strict_types=1);
+
+namespace InitPHP\Console;
+
+/**
+ * Read access to the tokens passed to a command after the command name.
+ *
+ * The parser recognises three token shapes:
+ *
+ * - **Arguments** — long, `--name` or `--name=value` form.
+ * - **Options**   — short, `-f`, `-abc` (combined) or `-key=value` form.
+ * - **Segments**  — bare positional tokens that carry neither `-` nor `--`.
+ *
+ * @see Input The default implementation.
+ */
+interface InputInterface
+{
+    /**
+     * Whether a `--name` argument was supplied.
+     *
+     * @param string $name Argument name without the leading dashes.
+     */
+    public function hasArgument(string $name): bool;
+
+    /**
+     * Returns the (type-cast) value of a `--name` argument.
+     *
+     * @param string $name    Argument name without the leading dashes.
+     * @param mixed  $default Value returned when the argument is absent.
+     * @return mixed
+     */
+    public function getArgument(string $name, $default = null);
+
+    /**
+     * All parsed arguments as a `name => value` map.
+     *
+     * @return array<string, mixed>
+     */
+    public function allArguments(): array;
+
+    /**
+     * Whether a positional segment exists at the given index.
+     */
+    public function hasSegment(int $index): bool;
+
+    /**
+     * Returns the (type-cast) positional segment at the given index.
+     *
+     * @param mixed $default Value returned when the index is absent.
+     * @return mixed
+     */
+    public function getSegment(int $index, $default = null);
+
+    /**
+     * All parsed positional segments in order.
+     *
+     * @return array<int, mixed>
+     */
+    public function allSegment(): array;
+
+    /**
+     * Whether a `-name` option was supplied.
+     *
+     * @param string $name Option name without the leading dash.
+     */
+    public function hasOption(string $name): bool;
+
+    /**
+     * Returns the (type-cast) value of a `-name` option.
+     *
+     * @param string $name    Option name without the leading dash.
+     * @param mixed  $default Value returned when the option is absent.
+     * @return mixed
+     */
+    public function getOption(string $name, $default = null);
+
+    /**
+     * All parsed options as a `name => value` map.
+     *
+     * @return array<string, mixed>
+     */
+    public function allOptions(): array;
+
+    /**
+     * Merges one or more `name => value` maps into the parsed arguments.
+     *
+     * Later maps overwrite earlier keys.
+     *
+     * @param array<string, mixed> ...$arguments
+     */
+    public function importArguments(array ...$arguments): void;
+}

--- a/src/Output.php
+++ b/src/Output.php
@@ -1,13 +1,13 @@
 <?php
+
 /**
  * Output.php
  *
- * This file is part of Console.
+ * This file is part of InitPHP Console.
  *
  * @author     Muhammet ŞAFAK <info@muhammetsafak.com.tr>
  * @copyright  Copyright © 2022 Muhammet ŞAFAK
- * @license    ./LICENSE  MIT
- * @version    2.0
+ * @license    https://github.com/InitPHP/Console/blob/main/LICENSE  MIT
  * @link       https://www.muhammetsafak.com.tr
  */
 
@@ -15,7 +15,14 @@ declare(strict_types=1);
 
 namespace InitPHP\Console;
 
-class Output
+/**
+ * Writes coloured/styled text to an output stream and reads interactive
+ * answers from an input stream.
+ *
+ * Both streams default to the standard CLI handles but may be injected — for
+ * example with `php://memory` handles — to make the component testable.
+ */
+class Output implements OutputInterface
 {
     public const COLOR_DEFAULT      = 39;
     public const COLOR_BLACK        = 30;
@@ -31,7 +38,7 @@ class Output
     public const COLOR_LIGHT_GREEN  = 92;
     public const COLOR_LIGHT_YELLOW = 93;
     public const COLOR_LIGHT_BLUE   = 94;
-    public const COLOR_LIGHT_MAGENTA= 95;
+    public const COLOR_LIGHT_MAGENTA = 95;
     public const COLOR_LIGHT_CYAN   = 96;
     public const COLOR_WHITE        = 97;
 
@@ -48,27 +55,75 @@ class Output
     public const UNDERLINE          = 4;
     public const STRIKETHROUGH      = 9;
 
-    function progressBar($done, $total) {
+    /**
+     * Stream that all output is written to.
+     *
+     * @var resource
+     */
+    protected $stdout;
 
-        if (!\is_numeric($done) || !\is_numeric($total)) {
-            throw new \InvalidArgumentException('\$done and \$total can be integer or float.');
-        }
+    /**
+     * Stream that interactive answers are read from.
+     *
+     * @var resource
+     */
+    protected $stdin;
 
-        $progress = \floor(($done / $total) * 100);
-        $done_progress = 100 - $progress;
-
-        \fwrite(\STDOUT, \sprintf("\033[0G\033[2K[%'=" . $progress . "s>%-" . $done_progress . "s] - " .$progress ."%%   ". $done . "/" . $total, "", ""));
+    /**
+     * @param resource|null $stdout Output stream; defaults to `STDOUT`.
+     * @param resource|null $stdin  Input stream; defaults to `STDIN`.
+     */
+    public function __construct($stdout = null, $stdin = null)
+    {
+        $this->stdout = $stdout ?? \STDOUT;
+        $this->stdin = $stdin ?? \STDIN;
     }
 
-    public function list(array $rows, int $leftSpace = 0)
+    /**
+     * Renders a single-line, in-place updating progress bar.
+     *
+     * @param int|float $done  Work completed so far.
+     * @param int|float $total Total work; must be greater than zero.
+     * @throws \InvalidArgumentException When the inputs are not numeric or `$total <= 0`.
+     */
+    public function progressBar($done, $total): void
+    {
+        if (!\is_numeric($done) || !\is_numeric($total)) {
+            throw new \InvalidArgumentException('$done and $total must be integer or float.');
+        }
+        if ($total <= 0) {
+            throw new \InvalidArgumentException('$total must be greater than zero.');
+        }
+
+        $progress = (int)\floor(($done / $total) * 100);
+        if ($progress < 0) {
+            $progress = 0;
+        } elseif ($progress > 100) {
+            $progress = 100;
+        }
+        $remaining = 100 - $progress;
+
+        \fwrite($this->stdout, \sprintf(
+            "\033[0G\033[2K[%'=" . $progress . "s>%-" . $remaining . "s] - %d%%   %s/%s",
+            '',
+            '',
+            $progress,
+            $done,
+            $total
+        ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function list(array $rows, int $leftSpace = 0): void
     {
         $space = 1;
-
         foreach ($rows as $key => $value) {
             if (!\is_string($key)) {
                 continue;
             }
-            $rowSpace = (int)\ceil(strlen($key) / 8);
+            $rowSpace = (int)\ceil(\strlen($key) / 8);
             if ($space < $rowSpace) {
                 $space = $rowSpace;
             }
@@ -81,53 +136,59 @@ class Output
                 $output .= $value;
                 continue;
             }
-            $line = $lineStart
+            $output .= $lineStart
                 . $key
                 . \str_repeat("\t", $space)
                 . ': '
-                . $value;
-            $output .= $line . \PHP_EOL;
+                . $value
+                . \PHP_EOL;
         }
-        \fwrite(\STDOUT, $output);
+        \fwrite($this->stdout, $output);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function ask(string $question, bool $empty = true)
     {
         $this->write($question, [], true);
 
         do {
-            $input = Helpers::strValueCast(\trim(\fgets(\STDIN)));
-            if (\in_array($input, ['exit', 'quit'])) {
-                exit;
+            $input = Helpers::strValueCast(\trim((string)\fgets($this->stdin)));
+            if (\in_array($input, ['exit', 'quit'], true)) {
+                $this->terminate();
+                return null;
             }
-        } while ($empty === FALSE && $input == '');
+        } while ($empty === false && $input === '');
 
         return $input;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function question(Question $question)
     {
         $this->write($question->getQuestion(), [], true);
 
         do {
-            $answer = \trim(\fgets(\STDIN));
+            $answer = \trim((string)\fgets($this->stdin));
             if ($question->hasOption($answer)) {
                 return Helpers::strValueCast($answer);
             }
-            if (\in_array($answer, ['exit', 'quit'])) {
-                exit;
+            if (\in_array($answer, ['exit', 'quit'], true)) {
+                $this->terminate();
+                return null;
             }
             if ($question->isOptional()) {
-                $default = $question->getDefault();
-                if ($default !== '__Qu€sti0nN0D€f@ultV@lue__') {
-                    return $default;
-                } else {
-                    return $answer;
-                }
+                return $question->hasDefault() ? $question->getDefault() : $answer;
             }
         } while (true);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function write(string $str, array $context = [], bool $newLine = false, array $format = [self::COLOR_DEFAULT]): void
     {
         if (!empty($context)) {
@@ -141,33 +202,60 @@ class Output
         }
 
         $msg = "\e[" . \implode(';', $format) . "m" . $str . "\e[0m"
-            . ($newLine !== FALSE ? \PHP_EOL : '');
-        \fwrite(\STDOUT, $msg);
+            . ($newLine ? \PHP_EOL : '');
+        \fwrite($this->stdout, $msg);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function writeln(string $str, array $context = [], array $format = [self::COLOR_DEFAULT]): void
     {
         $this->write($str, $context, true, $format);
     }
 
-    public function error(string $msg, array $context = array()): void
+    /**
+     * {@inheritDoc}
+     */
+    public function error(string $msg, array $context = []): void
     {
         $this->writeln('[ERROR] ' . $msg, $context, [self::COLOR_WHITE, self::BOLD, self::BACKGROUND_RED]);
     }
 
-    public function success(string $msg, array $context = array()): void
+    /**
+     * {@inheritDoc}
+     */
+    public function success(string $msg, array $context = []): void
     {
         $this->writeln('[SUCCESS] ' . $msg, $context, [self::COLOR_WHITE, self::BACKGROUND_GREEN, self::BOLD]);
     }
 
-    public function warning(string $msg, array $context = array()): void
+    /**
+     * {@inheritDoc}
+     */
+    public function warning(string $msg, array $context = []): void
     {
         $this->writeln('[WARNING] ' . $msg, $context, [self::COLOR_WHITE, self::BACKGROUND_YELLOW, self::BOLD]);
     }
 
-    public function info(string $msg, array $context = array()): void
+    /**
+     * {@inheritDoc}
+     */
+    public function info(string $msg, array $context = []): void
     {
         $this->writeln('[INFO] ' . $msg, $context, [self::COLOR_CYAN]);
     }
 
+    /**
+     * Terminates the current process.
+     *
+     * Extracted into a dedicated method so that interactive flows can be
+     * exercised in tests by overriding it (e.g. to throw instead of exit).
+     *
+     * @codeCoverageIgnore
+     */
+    protected function terminate(int $code = 0): void
+    {
+        exit($code);
+    }
 }

--- a/src/OutputInterface.php
+++ b/src/OutputInterface.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * OutputInterface.php
+ *
+ * This file is part of InitPHP Console.
+ *
+ * @author     Muhammet ŞAFAK <info@muhammetsafak.com.tr>
+ * @copyright  Copyright © 2022 Muhammet ŞAFAK
+ * @license    https://github.com/InitPHP/Console/blob/main/LICENSE  MIT
+ * @link       https://www.muhammetsafak.com.tr
+ */
+
+declare(strict_types=1);
+
+namespace InitPHP\Console;
+
+/**
+ * Writes formatted text to the console and reads interactive answers back.
+ *
+ * Formatting is expressed with the SGR (Select Graphic Rendition) integer
+ * codes exposed as constants on {@see Output} (colours, backgrounds and text
+ * styles such as {@see Output::BOLD}).
+ *
+ * @see Output The default implementation.
+ */
+interface OutputInterface
+{
+    /**
+     * Writes a string, optionally interpolating `{placeholder}` tokens and
+     * wrapping the result in SGR escape codes.
+     *
+     * @param string               $str     Text, possibly containing `{key}` placeholders.
+     * @param array<string, mixed> $context Replacement map for the placeholders.
+     * @param bool                 $newLine Whether to append a trailing newline.
+     * @param array<int, int>      $format  SGR codes applied to the whole string.
+     */
+    public function write(string $str, array $context = [], bool $newLine = false, array $format = []): void;
+
+    /**
+     * Same as {@see write()} but always appends a trailing newline.
+     *
+     * @param array<string, mixed> $context
+     * @param array<int, int>      $format
+     */
+    public function writeln(string $str, array $context = [], array $format = []): void;
+
+    /**
+     * Writes a key/value list, one `key : value` pair per line.
+     *
+     * @param array<string, mixed> $rows      The pairs to render.
+     * @param int                  $leftSpace Number of leading tab stops.
+     */
+    public function list(array $rows, int $leftSpace = 0): void;
+
+    /**
+     * Renders a single-line, in-place updating progress bar.
+     *
+     * @param int|float $done  Work completed so far.
+     * @param int|float $total Total work; must be greater than zero.
+     */
+    public function progressBar($done, $total): void;
+
+    /**
+     * Prints a question and blocks until the user submits a line.
+     *
+     * @param string $question The prompt to display.
+     * @param bool   $empty    When false, an empty answer is rejected and re-asked.
+     * @return mixed The type-cast answer.
+     */
+    public function ask(string $question, bool $empty = true);
+
+    /**
+     * Prints a {@see Question} and resolves the user's answer against it.
+     *
+     * @return mixed The accepted answer or the question's default.
+     */
+    public function question(Question $question);
+
+    /**
+     * Writes an error message styled as such.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function error(string $msg, array $context = []): void;
+
+    /**
+     * Writes a success message styled as such.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function success(string $msg, array $context = []): void;
+
+    /**
+     * Writes a warning message styled as such.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function warning(string $msg, array $context = []): void;
+
+    /**
+     * Writes an informational message styled as such.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function info(string $msg, array $context = []): void;
+}

--- a/src/Question.php
+++ b/src/Question.php
@@ -1,13 +1,13 @@
 <?php
+
 /**
  * Question.php
  *
- * This file is part of Console.
+ * This file is part of InitPHP Console.
  *
  * @author     Muhammet ŞAFAK <info@muhammetsafak.com.tr>
  * @copyright  Copyright © 2022 Muhammet ŞAFAK
- * @license    ./LICENSE  MIT
- * @version    2.0
+ * @license    https://github.com/InitPHP/Console/blob/main/LICENSE  MIT
  * @link       https://www.muhammetsafak.com.tr
  */
 
@@ -15,22 +15,62 @@ declare(strict_types=1);
 
 namespace InitPHP\Console;
 
+/**
+ * A value object describing an interactive question: its prompt, the set of
+ * acceptable answers, whether it is optional and its default answer.
+ *
+ * Instances are consumed by {@see Output::question()}.
+ */
 class Question
 {
+    /**
+     * Sentinel returned by {@see getDefault()} when no default has been set.
+     *
+     * Kept as a public constant for backwards compatibility; prefer
+     * {@see hasDefault()} to test for the presence of a default.
+     */
+    public const NO_DEFAULT = '__Qu€sti0nN0D€f@ultV@lue__';
 
+    /**
+     * @var string|null
+     */
     protected $question;
 
+    /**
+     * The set of acceptable answers.
+     *
+     * @var array<int|string, mixed>
+     */
     protected $options = [true, false];
 
+    /**
+     * @var bool
+     */
     protected $isOptional = false;
 
+    /**
+     * @var mixed
+     */
     protected $default;
 
+    /**
+     * @var bool
+     */
+    protected $defaultIsSet = false;
+
+    /**
+     * Whether an empty/non-matching answer is allowed to fall back to the default.
+     */
     public function isOptional(): bool
     {
         return $this->isOptional;
     }
 
+    /**
+     * Marks the question as optional.
+     *
+     * @return $this
+     */
     public function optional(): self
     {
         $this->isOptional = true;
@@ -38,6 +78,11 @@ class Question
         return $this;
     }
 
+    /**
+     * Marks the question as required.
+     *
+     * @return $this
+     */
     public function notOptional(): self
     {
         $this->isOptional = false;
@@ -45,11 +90,27 @@ class Question
         return $this;
     }
 
+    /**
+     * Whether the given answer is among the acceptable options.
+     *
+     * The answer is matched both verbatim and after {@see Helpers::strValueCast()}
+     * so that string input such as `"true"`/`"no"` matches boolean options.
+     */
     public function hasOption(string $option): bool
     {
-        return \in_array($option, $this->options);
+        if (\in_array($option, $this->options, true)) {
+            return true;
+        }
+
+        return \in_array(Helpers::strValueCast($option), $this->options, true);
     }
 
+    /**
+     * Replaces the full set of acceptable answers.
+     *
+     * @param array<int|string, mixed> $options
+     * @return $this
+     */
     public function setOptions(array $options): self
     {
         $this->options = $options;
@@ -57,13 +118,39 @@ class Question
         return $this;
     }
 
-    public function addOption(string $option, $value): self
+    /**
+     * Returns the acceptable answers.
+     *
+     * @return array<int|string, mixed>
+     */
+    public function getOptions(): array
     {
-        $this->options[] = $value;
+        return $this->options;
+    }
+
+    /**
+     * Adds a single acceptable answer.
+     *
+     * For backwards compatibility two-argument calls are still honoured: the
+     * second argument, when supplied, is the value that gets registered and the
+     * first acts only as a human-readable label.
+     *
+     * @param string $option Answer to register (or a label when `$value` is given).
+     * @param mixed  $value  Optional explicit value to register instead of `$option`.
+     * @return $this
+     */
+    public function addOption(string $option, $value = self::NO_DEFAULT): self
+    {
+        $this->options[] = $value === self::NO_DEFAULT ? $option : $value;
 
         return $this;
     }
 
+    /**
+     * Sets the prompt text.
+     *
+     * @return $this
+     */
     public function setQuestion(string $question): self
     {
         $this->question = $question;
@@ -71,21 +158,43 @@ class Question
         return $this;
     }
 
+    /**
+     * Returns the prompt text (empty string when unset).
+     */
     public function getQuestion(): string
     {
         return $this->question ?? '';
     }
 
+    /**
+     * Sets the default answer.
+     *
+     * @param mixed $default
+     * @return $this
+     */
     public function setDefault($default): self
     {
         $this->default = $default;
+        $this->defaultIsSet = true;
 
         return $this;
     }
 
-    public function getDefault()
+    /**
+     * Whether a default answer has been set.
+     */
+    public function hasDefault(): bool
     {
-        return $this->default ?? '__Qu€sti0nN0D€f@ultV@lue__';
+        return $this->defaultIsSet;
     }
 
+    /**
+     * Returns the default answer, or {@see NO_DEFAULT} when none was set.
+     *
+     * @return mixed
+     */
+    public function getDefault()
+    {
+        return $this->defaultIsSet ? $this->default : self::NO_DEFAULT;
+    }
 }

--- a/src/Utils/Table.php
+++ b/src/Utils/Table.php
@@ -1,22 +1,33 @@
 <?php
+
 /**
- * Application.php
+ * Table.php
  *
- * This file is part of Console.
+ * This file is part of InitPHP Console.
+ *
+ * Originally distributed as the standalone `initphp/cli-table` package, merged
+ * into `initphp/console` as of 2.1.
  *
  * @author     Muhammet ŞAFAK <info@muhammetsafak.com.tr>
  * @copyright  Copyright © 2022 Muhammet ŞAFAK
- * @license    ./LICENSE  MIT
- * @version    2.0
+ * @license    https://github.com/InitPHP/Console/blob/main/LICENSE  MIT
  * @link       https://www.muhammetsafak.com.tr
  */
 
 declare(strict_types=1);
+
 namespace InitPHP\Console\Utils;
 
+/**
+ * A lightweight, styleable ASCII/ANSI table renderer.
+ *
+ * Rows are supplied as associative arrays; the union of their keys forms the
+ * header. Columns are auto-sized, non-string cell values are stringified, and
+ * styles are emitted as SGR escape sequences. Multibyte values are measured
+ * with `mb_strlen()` when the extension is available.
+ */
 class Table
 {
-
     public const COLOR_DEFAULT      = 39;
     public const COLOR_BLACK        = 30;
     public const COLOR_RED          = 31;
@@ -31,7 +42,7 @@ class Table
     public const COLOR_LIGHT_GREEN  = 92;
     public const COLOR_LIGHT_YELLOW = 93;
     public const COLOR_LIGHT_BLUE   = 94;
-    public const COLOR_LIGHT_MAGENTA= 95;
+    public const COLOR_LIGHT_MAGENTA = 95;
     public const COLOR_LIGHT_CYAN   = 96;
     public const COLOR_WHITE        = 97;
 
@@ -48,16 +59,46 @@ class Table
     public const UNDERLINE          = 4;
     public const STRIKETHROUGH      = 9;
 
+    /**
+     * Placeholder used for missing cells.
+     */
+    private const NULL_PLACEHOLDER = '[NULL]';
+
+    /**
+     * SGR codes applied to the header row.
+     *
+     * @var array<int, int>
+     */
     private $headerStyle = [
         self::BOLD,
     ];
 
+    /**
+     * SGR codes applied to every body cell.
+     *
+     * @var array<int, int>
+     */
     private $cellStyle = [];
 
+    /**
+     * SGR codes applied to the border characters.
+     *
+     * @var array<int, int>
+     */
     private $borderStyle = [];
 
+    /**
+     * Per-column body-cell SGR codes, keyed by column name.
+     *
+     * @var array<string, array<int, int>>
+     */
     private $columnCellStyle = [];
 
+    /**
+     * The box-drawing characters used to build the frame.
+     *
+     * @var array<string, string>
+     */
     private $chars = [
         'top'          => '═',
         'top-mid'      => '╤',
@@ -76,98 +117,114 @@ class Table
         'middle'       => '│ ',
     ];
 
-    /** @var array */
+    /**
+     * The accumulated rows.
+     *
+     * @var array<int, array<string, string>>
+     */
     private $rows = [];
 
-    public function __construct()
-    {
-    }
-
-    public function __toString()
-    {
-        return $this->getContent();
-    }
-
+    /**
+     * Convenience factory for fluent construction.
+     */
     public static function create(): Table
     {
         return new self();
     }
 
+    /**
+     * Renders the table when the instance is used in a string context.
+     */
+    public function __toString(): string
+    {
+        return $this->getContent();
+    }
+
+    /**
+     * Sets the SGR codes applied to the header row.
+     *
+     * @param int ...$format One or more `self::*` style constants.
+     * @return $this
+     */
     public function setHeaderStyle(int ...$format): self
     {
-        $styles = [];
-        foreach ($format as $style) {
-            $styles[] = $style;
-        }
-        $this->headerStyle = $styles;
+        $this->headerStyle = $format;
+
         return $this;
     }
 
+    /**
+     * Sets the SGR codes applied to every body cell.
+     *
+     * @param int ...$format One or more `self::*` style constants.
+     * @return $this
+     */
     public function setCellStyle(int ...$format): self
     {
-        $styles = [];
-        foreach ($format as $style) {
-            $styles[] = $style;
-        }
-        $this->cellStyle = $styles;
+        $this->cellStyle = $format;
+
         return $this;
     }
 
+    /**
+     * Sets the SGR codes applied to the border characters.
+     *
+     * @param int ...$format One or more `self::*` style constants.
+     * @return $this
+     */
     public function setBorderStyle(int ...$format): self
     {
-        $styles = [];
-        foreach ($format as $style) {
-            $styles[] = $style;
-        }
-        $this->borderStyle = $styles;
+        $this->borderStyle = $format;
+
         return $this;
     }
 
+    /**
+     * Sets the SGR codes applied to the body cells of a single column.
+     *
+     * @param string $column   Column name.
+     * @param int    ...$format One or more `self::*` style constants.
+     * @return $this
+     */
     public function setColumnCellStyle(string $column, int ...$format): self
     {
-        $styles = [];
-        foreach ($format as $style) {
-            $styles[] = $style;
-        }
-        $this->columnCellStyle[$column] = $styles;
+        $this->columnCellStyle[$column] = $format;
+
         return $this;
     }
 
+    /**
+     * Appends a row.
+     *
+     * Keys become column names. Non-string values are stringified:
+     * objects to their class name, and `null`/booleans/resources/callables/
+     * arrays to bracketed placeholders.
+     *
+     * @param array<string, mixed> $assoc
+     * @return $this
+     */
     public function row(array $assoc): self
     {
         $row = [];
         foreach ($assoc as $key => $value) {
-            if(!\is_string($value)){
-                if(\is_object($value)){
-                    $value = \get_class($value);
-                }elseif (\is_resource($value)) {
-                    $value = '[RESOURCE]';
-                }elseif (\is_callable($value)){
-                    $value = '[CALLABLE]';
-                }elseif(\is_null($value)){
-                    $value = '[NULL]';
-                }elseif(\is_bool($value)){
-                    $value = $value === FALSE ? '[FALSE]' : '[TRUE]';
-                }else{
-                    $value = (string)$value;
-                }
-            }
-            $key = \trim((string)$key);
-            $row[$key] = \trim($value);
+            $row[\trim((string)$key)] = \trim($this->stringify($value));
         }
         $this->rows[] = $row;
+
         return $this;
     }
 
+    /**
+     * Renders the table to a string.
+     */
     public function getContent(): string
     {
-        $columnLengths = [];
         $headerData = [];
+        $columnLengths = [];
 
         foreach ($this->rows as $row) {
-            $keys = \array_keys($row);
-            foreach ($keys as $key) {
-                if(isset($headerData[$key])){
+            foreach (\array_keys($row) as $key) {
+                if (isset($headerData[$key])) {
                     continue;
                 }
                 $headerData[$key] = $key;
@@ -177,8 +234,8 @@ class Table
 
         foreach ($this->rows as $row) {
             foreach ($headerData as $column) {
-                $len = \max($columnLengths[$column], $this->strlen($row[$column]));
-                if($len % 2 !== 0){
+                $len = \max($columnLengths[$column], $this->strlen($row[$column] ?? self::NULL_PLACEHOLDER));
+                if ($len % 2 !== 0) {
                     ++$len;
                 }
                 $columnLengths[$column] = $len;
@@ -187,96 +244,146 @@ class Table
         foreach ($columnLengths as &$length) {
             $length += 4;
         }
+        unset($length);
 
         $res = $this->getTableTopContent($columnLengths)
             . $this->getFormattedRowContent($headerData, $columnLengths, "\e[" . \implode(';', $this->headerStyle) . "m", true)
             . $this->getTableSeparatorContent($columnLengths);
         foreach ($this->rows as $row) {
             foreach ($headerData as $column) {
-                if(!isset($row[$column])){
-                    $row[$column] = '[NULL]';
+                if (!isset($row[$column])) {
+                    $row[$column] = self::NULL_PLACEHOLDER;
                 }
             }
             $res .= $this->getFormattedRowContent($row, $columnLengths, "\e[" . \implode(';', $this->cellStyle) . "m");
         }
+
         return $res . $this->getTableBottomContent($columnLengths);
     }
 
-    private function getFormattedRowContent($data, $lengths, string $format = '', bool $isHeader = false): string
+    /**
+     * Coerces a cell value into a printable string.
+     *
+     * @param mixed $value
+     */
+    private function stringify($value): string
+    {
+        if (\is_string($value)) {
+            return $value;
+        }
+        if (\is_object($value)) {
+            return \get_class($value);
+        }
+        if (\is_resource($value)) {
+            return '[RESOURCE]';
+        }
+        if (\is_array($value)) {
+            return \is_callable($value) ? '[CALLABLE]' : '[ARRAY]';
+        }
+        if (\is_callable($value)) {
+            return '[CALLABLE]';
+        }
+        if ($value === null) {
+            return self::NULL_PLACEHOLDER;
+        }
+        if (\is_bool($value)) {
+            return $value === false ? '[FALSE]' : '[TRUE]';
+        }
+
+        return (string)$value;
+    }
+
+    /**
+     * Builds a single (header or body) row line.
+     *
+     * @param array<string, string> $data
+     * @param array<string, int>    $lengths
+     */
+    private function getFormattedRowContent(array $data, array $lengths, string $format = '', bool $isHeader = false): string
     {
         $res = $this->getChar('left') . ' ';
-        $rows = [];
+        $cells = [];
         foreach ($data as $key => $value) {
             $customFormat = '';
             $value = ' ' . $value;
             $len = $this->strlen($value) - $lengths[$key] + 1;
-            if($isHeader === FALSE && isset($this->columnCellStyle[$key]) && !empty($this->columnCellStyle[$key])){
-                $customFormat = "\e[" . \implode(";", $this->columnCellStyle[$key]) . "m";
+            if ($isHeader === false && !empty($this->columnCellStyle[$key])) {
+                $customFormat = "\e[" . \implode(';', $this->columnCellStyle[$key]) . "m";
             }
-            $rows[] = ($format !== '' ? $format : '')
-                . ($customFormat !== '' ? $customFormat : '')
+            $cells[] = $format
+                . $customFormat
                 . $value
                 . ($format !== '' || $customFormat !== '' ? "\e[0m" : '')
                 . \str_repeat(' ', (int)\abs($len));
         }
-        $res .= \implode($this->getChar('middle'), $rows);
+        $res .= \implode($this->getChar('middle'), $cells);
+
         return $res . $this->getChar('right') . \PHP_EOL;
     }
 
-    private function getTableTopContent($lengths): string
+    /**
+     * @param array<string, int> $lengths
+     */
+    private function getTableTopContent(array $lengths): string
     {
-        $res = $this->getChar('top-left');
-        $rows = [];
-        foreach ($lengths as $length) {
-            $rows[] = $this->getChar('top', $length);
-        }
-        $res .= \implode($this->getChar('top-mid'), $rows);
-        return  $res . $this->getChar('top-right') . \PHP_EOL;
+        return $this->buildRule($lengths, 'top-left', 'top', 'top-mid', 'top-right');
     }
 
-    private function getTableBottomContent($lengths): string
+    /**
+     * @param array<string, int> $lengths
+     */
+    private function getTableBottomContent(array $lengths): string
     {
-        $res = $this->getChar('bottom-left');
-        $rows = [];
-        foreach ($lengths as $length) {
-            $rows[] = $this->getChar('bottom', $length);
-        }
-        $res .= \implode($this->getChar('bottom-mid'), $rows);
-        return $res . $this->getChar('bottom-right') . \PHP_EOL;
+        return $this->buildRule($lengths, 'bottom-left', 'bottom', 'bottom-mid', 'bottom-right');
     }
 
-    private function getTableSeparatorContent($lengths): string
+    /**
+     * @param array<string, int> $lengths
+     */
+    private function getTableSeparatorContent(array $lengths): string
     {
-        $res = $this->getChar('left-mid');
-        $rows = [];
-        foreach ($lengths as $length) {
-            $rows[] = $this->getChar('mid', $length);
-        }
-        $res .= \implode($this->getChar('mid-mid'), $rows);
-        return $res . $this->getChar('right-mid') . \PHP_EOL;
+        return $this->buildRule($lengths, 'left-mid', 'mid', 'mid-mid', 'right-mid');
     }
 
+    /**
+     * Builds a horizontal rule (top, separator or bottom) from the given chars.
+     *
+     * @param array<string, int> $lengths
+     */
+    private function buildRule(array $lengths, string $left, string $fill, string $mid, string $right): string
+    {
+        $cells = [];
+        foreach ($lengths as $length) {
+            $cells[] = $this->getChar($fill, $length);
+        }
+
+        return $this->getChar($left) . \implode($this->getChar($mid), $cells) . $this->getChar($right) . \PHP_EOL;
+    }
+
+    /**
+     * Returns a border character (optionally repeated) wrapped in the border style.
+     */
     private function getChar(string $char, int $len = 1): string
     {
-        if(!isset($this->chars[$char])){
+        if (!isset($this->chars[$char])) {
             return '';
         }
-        $res = (empty($this->borderStyle) ? '' : "\e[" . \implode(";", $this->borderStyle) . "m");
-        if($len === 1){
-            $res .= $this->chars[$char];;
-        }else{
-            $res .= \str_repeat($this->chars[$char], $len);
-        }
+        $res = empty($this->borderStyle) ? '' : "\e[" . \implode(';', $this->borderStyle) . "m";
+        $res .= $len === 1 ? $this->chars[$char] : \str_repeat($this->chars[$char], $len);
         $res .= empty($this->borderStyle) ? '' : "\e[0m";
+
         return $res;
     }
 
+    /**
+     * Multibyte-aware string length, falling back to `strlen()` when needed.
+     */
     private function strlen(string $str): int
     {
-        if(!\function_exists('mb_strlen')){
+        if (!\function_exists('mb_strlen')) {
             return \strlen($str);
         }
+
         return \mb_strlen($str);
     }
-
 }

--- a/src/aliases.php
+++ b/src/aliases.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * aliases.php
  *

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console;
+
+use InitPHP\Console\Application;
+use InitPHP\Console\Input;
+use InitPHP\Console\Output;
+use PHPUnit\Framework\TestCase;
+use Test\InitPHP\Console\Fixtures\BadArgsCommand;
+use Test\InitPHP\Console\Fixtures\GreetCommand;
+use Test\InitPHP\Console\Fixtures\NoNameCommand;
+use Test\InitPHP\Console\Fixtures\RequiredArgCommand;
+use Test\InitPHP\Console\Support\MemoryOutput;
+
+final class ApplicationTest extends TestCase
+{
+    private function app(MemoryOutput $output): Application
+    {
+        return new Application('My App', '1.2.3', $output);
+    }
+
+    public function testRegisterReturnsSelf(): void
+    {
+        $app = $this->app(new MemoryOutput());
+
+        self::assertSame($app, $app->register('noop', static function (): void {
+        }));
+    }
+
+    public function testRegisterRejectsUnknownClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->app(new MemoryOutput())->register('This\\Class\\Does\\Not\\Exist');
+    }
+
+    public function testRegisterRejectsNonCommandClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->app(new MemoryOutput())->register(\stdClass::class);
+    }
+
+    public function testRegisterRejectsCommandWithoutName(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->app(new MemoryOutput())->register(NoNameCommand::class);
+    }
+
+    public function testRunReturnsFalseWhenNoCommandGiven(): void
+    {
+        $out = new MemoryOutput();
+        self::assertFalse($this->app($out)->run(['console.php']));
+    }
+
+    public function testRunReportsUnknownCommand(): void
+    {
+        $out = new MemoryOutput();
+
+        self::assertTrue($this->app($out)->run(['console.php', 'ghost']));
+        self::assertStringContainsString('command was not found', $out->plain());
+    }
+
+    public function testRunDispatchesClosureWithInputAndOutput(): void
+    {
+        $out = new MemoryOutput();
+        $app = $this->app($out);
+        $app->register('hello', static function (Input $input, Output $output): void {
+            $output->writeln('Hello {n}', ['n' => $input->getArgument('name', 'nobody')]);
+        }, 'Say hello.');
+
+        self::assertTrue($app->run(['console.php', 'hello', '--name=Sam']));
+        self::assertStringContainsString('Hello Sam', $out->plain());
+    }
+
+    public function testRunCatchesThrowableFromCommand(): void
+    {
+        $out = new MemoryOutput();
+        $app = $this->app($out);
+        $app->register('boom', static function (): void {
+            throw new \RuntimeException('kaboom');
+        });
+
+        self::assertFalse($app->run(['console.php', 'boom']));
+        self::assertStringContainsString('kaboom', $out->plain());
+    }
+
+    public function testRunDispatchesCommandClassAndValidatesArguments(): void
+    {
+        $out = new MemoryOutput();
+        $app = $this->app($out);
+        $app->register(GreetCommand::class);
+
+        self::assertTrue($app->run(['console.php', 'app:greet', '--name=Ada']));
+        self::assertStringContainsString('Hi Ada', $out->plain());
+    }
+
+    public function testCommandClassUsesArgumentDefault(): void
+    {
+        $out = new MemoryOutput();
+        $app = $this->app($out);
+        $app->register(GreetCommand::class);
+
+        self::assertTrue($app->run(['console.php', 'app:greet']));
+        self::assertStringContainsString('Hi World', $out->plain());
+    }
+
+    public function testRequiredArgumentMissingAbortsBeforeExecute(): void
+    {
+        $out = new MemoryOutput();
+        $app = $this->app($out);
+        $app->register(RequiredArgCommand::class);
+
+        self::assertFalse($app->run(['console.php', 'app:req']));
+        self::assertStringContainsString('--id', $out->plain());
+        self::assertStringNotContainsString('EXECUTED', $out->plain());
+    }
+
+    public function testRequiredArgumentProvidedRunsExecute(): void
+    {
+        $out = new MemoryOutput();
+        $app = $this->app($out);
+        $app->register(RequiredArgCommand::class);
+
+        self::assertTrue($app->run(['console.php', 'app:req', '--id=5']));
+        self::assertStringContainsString('EXECUTED id=5', $out->plain());
+    }
+
+    public function testInvalidArgumentDefinitionAborts(): void
+    {
+        $out = new MemoryOutput();
+        $app = $this->app($out);
+        $app->register(BadArgsCommand::class);
+
+        self::assertFalse($app->run(['console.php', 'app:bad']));
+        self::assertStringNotContainsString('EXECUTED', $out->plain());
+    }
+
+    public function testListRendersRegisteredCommands(): void
+    {
+        $out = new MemoryOutput();
+        $app = $this->app($out);
+        $app->register(GreetCommand::class);
+        $app->register('solo', static function (): void {
+        }, 'A solo command.');
+
+        self::assertTrue($app->run(['console.php', 'list']));
+        $plain = $out->plain();
+        self::assertStringContainsString('My App v1.2.3', $plain);
+        self::assertStringContainsString('app:greet', $plain);
+        self::assertStringContainsString('solo', $plain);
+    }
+
+    public function testCommandHelpRendersUsage(): void
+    {
+        $out = new MemoryOutput();
+        $app = $this->app($out);
+        $app->register(GreetCommand::class);
+
+        self::assertTrue($app->run(['console.php', 'app:greet', '--help']));
+        $plain = $out->plain();
+        self::assertStringContainsString('[USAGE]', $plain);
+        self::assertStringContainsString('[PARAMETERS]', $plain);
+        self::assertStringContainsString('app:greet', $plain);
+    }
+}

--- a/tests/Fixtures/BadArgsCommand.php
+++ b/tests/Fixtures/BadArgsCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console\Fixtures;
+
+use InitPHP\Console\Command;
+use InitPHP\Console\Input;
+use InitPHP\Console\Output;
+
+/**
+ * A command whose {@see arguments()} contains an entry that is not an
+ * {@see \InitPHP\Console\InputArgument}.
+ */
+final class BadArgsCommand extends Command
+{
+    /** @var string */
+    public $command = 'app:bad';
+
+    public function arguments(): array
+    {
+        return ['not-an-input-argument'];
+    }
+
+    public function execute(Input $input, Output $output)
+    {
+        $output->writeln('EXECUTED');
+    }
+}

--- a/tests/Fixtures/GreetCommand.php
+++ b/tests/Fixtures/GreetCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console\Fixtures;
+
+use InitPHP\Console\Command;
+use InitPHP\Console\Input;
+use InitPHP\Console\InputArgument;
+use InitPHP\Console\Output;
+
+final class GreetCommand extends Command
+{
+    /** @var string */
+    public $command = 'app:greet';
+
+    public function definition(): string
+    {
+        return 'Greets someone.';
+    }
+
+    public function help(): string
+    {
+        return 'Prints a greeting to the given name.';
+    }
+
+    public function arguments(): array
+    {
+        return [
+            new InputArgument('name', InputArgument::STR, 'World', true, 'Who to greet.'),
+        ];
+    }
+
+    public function execute(Input $input, Output $output)
+    {
+        $output->writeln('Hi {name}', ['name' => $input->getArgument('name')]);
+    }
+}

--- a/tests/Fixtures/NoNameCommand.php
+++ b/tests/Fixtures/NoNameCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console\Fixtures;
+
+use InitPHP\Console\Command;
+use InitPHP\Console\Input;
+use InitPHP\Console\Output;
+
+/**
+ * A command that (incorrectly) never declares its {@see Command::$command} name.
+ */
+final class NoNameCommand extends Command
+{
+    public function execute(Input $input, Output $output)
+    {
+    }
+}

--- a/tests/Fixtures/RequiredArgCommand.php
+++ b/tests/Fixtures/RequiredArgCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console\Fixtures;
+
+use InitPHP\Console\Command;
+use InitPHP\Console\Input;
+use InitPHP\Console\InputArgument;
+use InitPHP\Console\Output;
+
+final class RequiredArgCommand extends Command
+{
+    /** @var string */
+    public $command = 'app:req';
+
+    public function arguments(): array
+    {
+        return [
+            new InputArgument('id', InputArgument::INT, 0, false, 'Required id.'),
+        ];
+    }
+
+    public function execute(Input $input, Output $output)
+    {
+        $output->writeln('EXECUTED id={id}', ['id' => $input->getArgument('id')]);
+    }
+}

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console;
+
+use InitPHP\Console\Helpers;
+use PHPUnit\Framework\TestCase;
+
+final class HelpersTest extends TestCase
+{
+    /**
+     * @dataProvider castProvider
+     * @param mixed $expected
+     */
+    public function testStrValueCast(string $input, $expected): void
+    {
+        self::assertSame($expected, Helpers::strValueCast($input));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: mixed}>
+     */
+    public static function castProvider(): array
+    {
+        return [
+            'empty string'        => ['', ''],
+            'null literal'        => ['null', null],
+            'NULL upper'          => ['NULL', null],
+            'true'                => ['true', true],
+            'yes'                 => ['yes', true],
+            'false'               => ['false', false],
+            'no'                  => ['no', false],
+            'positive int'        => ['42', 42],
+            'signed negative int' => ['-7', -7],
+            'signed positive int' => ['+7', 7],
+            'float dot'           => ['3.14', 3.14],
+            'float comma'         => ['3,14', 3.14],
+            'plain string'        => ['hello', 'hello'],
+            // Regression: pipe must not be treated as a sign (old [-|+] class bug).
+            'pipe is not numeric' => ['|123', '|123'],
+            'pipe float guard'    => ['1|2', '1|2'],
+            'double sign guard'   => ['--5', '--5'],
+            'leading zero string' => ['007', 7],
+        ];
+    }
+}

--- a/tests/InputArgumentTest.php
+++ b/tests/InputArgumentTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console;
+
+use InitPHP\Console\Input;
+use InitPHP\Console\InputArgument;
+use PHPUnit\Framework\TestCase;
+use Test\InitPHP\Console\Support\MemoryOutput;
+
+final class InputArgumentTest extends TestCase
+{
+    public function testConstructorRejectsUnsupportedType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new InputArgument('x', 'NOPE', null);
+    }
+
+    public function testConstructorRejectsDefaultNotMatchingType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new InputArgument('age', InputArgument::INT, 'not-an-int');
+    }
+
+    public function testGetters(): void
+    {
+        $arg = new InputArgument('age', InputArgument::INT, 18, false, 'The age.');
+
+        self::assertSame('--age', $arg->getName());
+        self::assertSame(InputArgument::INT, $arg->getType());
+        self::assertSame('The age.', $arg->getDefinition());
+        self::assertSame('18', $arg->getDefault());
+        self::assertFalse($arg->isOptional());
+    }
+
+    public function testOptionalMissingArgumentUsesDefault(): void
+    {
+        $arg = new InputArgument('name', InputArgument::STR, 'guest');
+        $input = new Input([]);
+
+        self::assertTrue($arg->run($input, new MemoryOutput()));
+        self::assertSame('guest', $input->getArgument('name'));
+    }
+
+    public function testRequiredMissingArgumentFailsWithError(): void
+    {
+        $arg = new InputArgument('name', InputArgument::STR, 'guest', false);
+        $input = new Input([]);
+        $output = new MemoryOutput();
+
+        self::assertFalse($arg->run($input, $output));
+        self::assertStringContainsString('--name', $output->plain());
+    }
+
+    public function testValidValueIsAccepted(): void
+    {
+        $arg = new InputArgument('age', InputArgument::INT, 0);
+        $input = new Input(['--age=42']);
+
+        self::assertTrue($arg->run($input, new MemoryOutput()));
+        self::assertSame(42, $input->getArgument('age'));
+    }
+
+    public function testInvalidOptionalValueFallsBackToDefault(): void
+    {
+        $arg = new InputArgument('age', InputArgument::INT, 7);
+        $input = new Input(['--age=abc']);
+
+        self::assertTrue($arg->run($input, new MemoryOutput()));
+        self::assertSame(7, $input->getArgument('age'));
+    }
+
+    public function testZeroValueForRequiredArgumentIsPreserved(): void
+    {
+        // Regression: the old empty() check replaced legitimate 0 with the default.
+        $arg = new InputArgument('count', InputArgument::INT, 99, false);
+        $input = new Input(['--count=0']);
+
+        self::assertTrue($arg->run($input, new MemoryOutput()));
+        self::assertSame(0, $input->getArgument('count'));
+    }
+
+    public function testBoolCoercionFromOneZero(): void
+    {
+        $arg = new InputArgument('flag', InputArgument::BOOL, false);
+        $input = new Input(['--flag=1']);
+
+        self::assertTrue($arg->run($input, new MemoryOutput()));
+        self::assertTrue($input->getArgument('flag'));
+    }
+
+    public function testValueCanComeFromShortOption(): void
+    {
+        $arg = new InputArgument('n', InputArgument::NUMERIC, 0);
+        $input = new Input(['-n=12']);
+
+        self::assertTrue($arg->run($input, new MemoryOutput()));
+        self::assertSame(12, $input->getArgument('n'));
+    }
+}

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console;
+
+use InitPHP\Console\Input;
+use InitPHP\Console\InputInterface;
+use PHPUnit\Framework\TestCase;
+
+final class InputTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        self::assertInstanceOf(InputInterface::class, new Input([]));
+    }
+
+    public function testLongArgumentsWithAndWithoutValues(): void
+    {
+        $input = new Input(['--name=John', '--verbose']);
+
+        self::assertTrue($input->hasArgument('name'));
+        self::assertSame('John', $input->getArgument('name'));
+        self::assertTrue($input->hasArgument('verbose'));
+        self::assertSame('', $input->getArgument('verbose'));
+        self::assertFalse($input->hasArgument('missing'));
+        self::assertSame('fallback', $input->getArgument('missing', 'fallback'));
+        self::assertSame(['name' => 'John', 'verbose' => ''], $input->allArguments());
+    }
+
+    public function testArgumentValuesAreTypeCast(): void
+    {
+        $input = new Input(['--age=30', '--ratio=1.5', '--active=true']);
+
+        self::assertSame(30, $input->getArgument('age'));
+        self::assertSame(1.5, $input->getArgument('ratio'));
+        self::assertTrue($input->getArgument('active'));
+    }
+
+    public function testSingleShortOption(): void
+    {
+        $input = new Input(['-v']);
+
+        self::assertTrue($input->hasOption('v'));
+        self::assertSame('v', $input->getOption('v'));
+    }
+
+    public function testCombinedShortOptionsDoNotLeakAggregateKey(): void
+    {
+        $input = new Input(['-abc']);
+
+        // Regression: the old parser also stored a bogus "abc" key.
+        self::assertSame(['a' => 'a', 'b' => 'b', 'c' => 'c'], $input->allOptions());
+        self::assertFalse($input->hasOption('abc'));
+    }
+
+    public function testShortOptionWithValue(): void
+    {
+        $input = new Input(['-level=5']);
+
+        self::assertSame(5, $input->getOption('level'));
+        self::assertSame('def', $input->getOption('nope', 'def'));
+    }
+
+    public function testSegmentsAreCollectedAndCast(): void
+    {
+        $input = new Input(['foo', '10', '--flag=x']);
+
+        self::assertTrue($input->hasSegment(0));
+        self::assertSame('foo', $input->getSegment(0));
+        self::assertSame(10, $input->getSegment(1));
+        self::assertFalse($input->hasSegment(5));
+        self::assertSame('d', $input->getSegment(5, 'd'));
+        self::assertSame(['foo', 10], $input->allSegment());
+    }
+
+    public function testBareDashTokenIsIgnored(): void
+    {
+        $input = new Input(['--', '-', 'real']);
+
+        self::assertSame([], $input->allArguments());
+        self::assertSame([], $input->allOptions());
+        self::assertSame(['real'], $input->allSegment());
+    }
+
+    public function testImportArgumentsMerges(): void
+    {
+        $input = new Input(['--a=1']);
+        $input->importArguments(['b' => 2], ['c' => 3]);
+
+        self::assertSame(['a' => 1, 'b' => 2, 'c' => 3], $input->allArguments());
+    }
+}

--- a/tests/OutputTest.php
+++ b/tests/OutputTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console;
+
+use InitPHP\Console\Output;
+use InitPHP\Console\OutputInterface;
+use InitPHP\Console\Question;
+use PHPUnit\Framework\TestCase;
+use Test\InitPHP\Console\Support\MemoryOutput;
+use Test\InitPHP\Console\Support\TerminateException;
+
+final class OutputTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        self::assertInstanceOf(OutputInterface::class, new MemoryOutput());
+    }
+
+    public function testWriteInterpolatesContextAndWrapsInSgr(): void
+    {
+        $out = new MemoryOutput();
+        $out->write('Hello {name}', ['name' => 'Bob']);
+
+        self::assertSame('Hello Bob', $out->plain());
+        self::assertStringContainsString("\e[", $out->captured());
+        self::assertStringContainsString("\e[0m", $out->captured());
+    }
+
+    public function testWriteIgnoresArrayAndNonStringableObjectContext(): void
+    {
+        $out = new MemoryOutput();
+        $out->write('A {arr} B {obj}', ['arr' => [1, 2], 'obj' => new \stdClass()]);
+
+        self::assertSame('A {arr} B {obj}', $out->plain());
+    }
+
+    public function testWritelnAppendsNewline(): void
+    {
+        $out = new MemoryOutput();
+        $out->writeln('line');
+
+        self::assertStringEndsWith(\PHP_EOL, $out->captured());
+        self::assertSame('line' . \PHP_EOL, $out->plain());
+    }
+
+    public function testMessageHelpersArePrefixed(): void
+    {
+        $out = new MemoryOutput();
+        $out->error('boom');
+        $out->success('great');
+        $out->warning('careful');
+        $out->info('fyi');
+
+        $plain = $out->plain();
+        self::assertStringContainsString('[ERROR] boom', $plain);
+        self::assertStringContainsString('[SUCCESS] great', $plain);
+        self::assertStringContainsString('[WARNING] careful', $plain);
+        self::assertStringContainsString('[INFO] fyi', $plain);
+    }
+
+    public function testList(): void
+    {
+        $out = new MemoryOutput();
+        $out->list(['name' => 'value', 'k' => 'v']);
+
+        $plain = $out->plain();
+        self::assertStringContainsString('name', $plain);
+        self::assertStringContainsString(': value', $plain);
+        self::assertStringContainsString(': v', $plain);
+    }
+
+    public function testProgressBarRendersPercentageAndRatio(): void
+    {
+        $out = new MemoryOutput();
+        $out->progressBar(50, 100);
+
+        $captured = $out->captured();
+        self::assertStringContainsString('50%', $captured);
+        self::assertStringContainsString('50/100', $captured);
+    }
+
+    public function testProgressBarRejectsNonNumeric(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        (new MemoryOutput())->progressBar('a', 'b');
+    }
+
+    public function testProgressBarRejectsZeroTotal(): void
+    {
+        // Regression: division-by-zero guard.
+        $this->expectException(\InvalidArgumentException::class);
+        (new MemoryOutput())->progressBar(1, 0);
+    }
+
+    public function testAskReturnsCastAnswer(): void
+    {
+        $out = new MemoryOutput("42\n");
+
+        self::assertSame(42, $out->ask('How many?'));
+        self::assertStringContainsString('How many?', $out->plain());
+    }
+
+    public function testAskRejectsEmptyWhenNotAllowed(): void
+    {
+        $out = new MemoryOutput("\n  \nfinally\n");
+
+        self::assertSame('finally', $out->ask('Value:', false));
+    }
+
+    public function testAskExitTerminates(): void
+    {
+        $out = new MemoryOutput("exit\n");
+
+        $this->expectException(TerminateException::class);
+        $out->ask('Value:');
+    }
+
+    public function testQuestionReturnsMatchingOption(): void
+    {
+        $out = new MemoryOutput("red\n");
+        $question = (new Question())->setQuestion('Colour?')->setOptions(['red', 'green']);
+
+        self::assertSame('red', $out->question($question));
+    }
+
+    public function testQuestionFallsBackToDefaultWhenOptional(): void
+    {
+        $out = new MemoryOutput("purple\n");
+        $question = (new Question())
+            ->setQuestion('Colour?')
+            ->setOptions(['red'])
+            ->optional()
+            ->setDefault('blue');
+
+        self::assertSame('blue', $out->question($question));
+    }
+
+    public function testQuestionQuitTerminates(): void
+    {
+        $out = new MemoryOutput("quit\n");
+        $question = (new Question())->setQuestion('Colour?')->setOptions(['red']);
+
+        $this->expectException(TerminateException::class);
+        $out->question($question);
+    }
+
+    public function testDefaultConstructorUsesStandardStreams(): void
+    {
+        // Construction must not require arguments (BC) and must not write anything.
+        $out = new Output();
+        self::assertInstanceOf(OutputInterface::class, $out);
+    }
+}

--- a/tests/QuestionTest.php
+++ b/tests/QuestionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console;
+
+use InitPHP\Console\Question;
+use PHPUnit\Framework\TestCase;
+
+final class QuestionTest extends TestCase
+{
+    public function testFluentSettersReturnSelf(): void
+    {
+        $q = new Question();
+
+        self::assertSame($q, $q->setQuestion('Q?'));
+        self::assertSame($q, $q->optional());
+        self::assertSame($q, $q->notOptional());
+        self::assertSame($q, $q->setOptions(['a']));
+        self::assertSame($q, $q->setDefault('x'));
+        self::assertSame($q, $q->addOption('b'));
+    }
+
+    public function testQuestionTextDefaultsToEmpty(): void
+    {
+        self::assertSame('', (new Question())->getQuestion());
+        self::assertSame('Ready?', (new Question())->setQuestion('Ready?')->getQuestion());
+    }
+
+    public function testDefaultBooleanOptionsMatchCastStrings(): void
+    {
+        $q = new Question();
+
+        // Regression: the old loose in_array() matched every non-empty answer.
+        self::assertTrue($q->hasOption('true'));
+        self::assertTrue($q->hasOption('false'));
+        self::assertTrue($q->hasOption('yes'));
+        self::assertFalse($q->hasOption('maybe'));
+    }
+
+    public function testCustomStringOptions(): void
+    {
+        $q = (new Question())->setOptions(['red', 'green']);
+
+        self::assertTrue($q->hasOption('red'));
+        self::assertFalse($q->hasOption('blue'));
+        self::assertSame(['red', 'green'], $q->getOptions());
+    }
+
+    public function testAddOptionSingleArgumentRegistersTheOption(): void
+    {
+        $q = (new Question())->setOptions([])->addOption('alpha');
+
+        self::assertSame(['alpha'], $q->getOptions());
+        self::assertTrue($q->hasOption('alpha'));
+    }
+
+    public function testAddOptionTwoArgumentLegacyFormRegistersTheValue(): void
+    {
+        $q = (new Question())->setOptions([])->addOption('Label', 'value');
+
+        self::assertSame(['value'], $q->getOptions());
+        self::assertTrue($q->hasOption('value'));
+    }
+
+    public function testDefaultHandling(): void
+    {
+        $q = new Question();
+        self::assertFalse($q->hasDefault());
+        self::assertSame(Question::NO_DEFAULT, $q->getDefault());
+
+        $q->setDefault('home');
+        self::assertTrue($q->hasDefault());
+        self::assertSame('home', $q->getDefault());
+    }
+
+    public function testNullDefaultIsStillADefault(): void
+    {
+        $q = (new Question())->setDefault(null);
+
+        self::assertTrue($q->hasDefault());
+        self::assertNull($q->getDefault());
+    }
+
+    public function testOptionalState(): void
+    {
+        $q = new Question();
+        self::assertFalse($q->isOptional());
+        self::assertTrue($q->optional()->isOptional());
+        self::assertFalse($q->notOptional()->isOptional());
+    }
+}

--- a/tests/Support/MemoryOutput.php
+++ b/tests/Support/MemoryOutput.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console\Support;
+
+use InitPHP\Console\Output;
+
+/**
+ * Test double that captures everything written to an in-memory stream and
+ * turns the interactive {@see Output::terminate()} call into an exception so
+ * that `exit`/`quit` flows can be asserted without killing the test runner.
+ */
+final class MemoryOutput extends Output
+{
+    /** @var resource */
+    private $buffer;
+
+    /**
+     * @param string $stdinContent Pre-seeded answers read by ask()/question().
+     */
+    public function __construct(string $stdinContent = '')
+    {
+        $buffer = \fopen('php://memory', 'r+');
+        $stdin = \fopen('php://memory', 'r+');
+        \fwrite($stdin, $stdinContent);
+        \rewind($stdin);
+
+        $this->buffer = $buffer;
+        parent::__construct($buffer, $stdin);
+    }
+
+    /**
+     * Returns everything written so far.
+     */
+    public function captured(): string
+    {
+        \rewind($this->buffer);
+
+        return (string)\stream_get_contents($this->buffer);
+    }
+
+    /**
+     * Returns the captured output with SGR escape sequences stripped.
+     */
+    public function plain(): string
+    {
+        return (string)\preg_replace('/\e\[[0-9;]*m/', '', $this->captured());
+    }
+
+    /**
+     * @throws TerminateException instead of exiting the process.
+     */
+    protected function terminate(int $code = 0): void
+    {
+        throw new TerminateException('terminated', $code);
+    }
+}

--- a/tests/Support/TerminateException.php
+++ b/tests/Support/TerminateException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console\Support;
+
+/**
+ * Thrown by {@see MemoryOutput::terminate()} in place of `exit`.
+ */
+final class TerminateException extends \RuntimeException
+{
+}

--- a/tests/Utils/TableTest.php
+++ b/tests/Utils/TableTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\InitPHP\Console\Utils;
+
+use InitPHP\Console\Utils\Table;
+use PHPUnit\Framework\TestCase;
+
+final class TableTest extends TestCase
+{
+    public function testCreateReturnsInstanceAndStringCastEqualsGetContent(): void
+    {
+        $table = Table::create()->row(['id' => 1, 'name' => 'Ada']);
+
+        self::assertInstanceOf(Table::class, $table);
+        self::assertSame($table->getContent(), (string)$table);
+    }
+
+    public function testFluentSettersReturnSelf(): void
+    {
+        $table = Table::create();
+
+        self::assertSame($table, $table->setHeaderStyle(Table::BOLD));
+        self::assertSame($table, $table->setCellStyle(Table::COLOR_GREEN));
+        self::assertSame($table, $table->setBorderStyle(Table::COLOR_BLUE));
+        self::assertSame($table, $table->setColumnCellStyle('id', Table::COLOR_RED));
+        self::assertSame($table, $table->row(['id' => 1]));
+    }
+
+    public function testRendersHeadersValuesAndFrame(): void
+    {
+        $content = Table::create()
+            ->row(['id' => 1, 'name' => 'Ada'])
+            ->row(['id' => 2, 'name' => 'Bob'])
+            ->getContent();
+
+        self::assertStringContainsString('id', $content);
+        self::assertStringContainsString('name', $content);
+        self::assertStringContainsString('Ada', $content);
+        self::assertStringContainsString('Bob', $content);
+        // Frame corners.
+        self::assertStringContainsString('╔', $content);
+        self::assertStringContainsString('╝', $content);
+    }
+
+    public function testRaggedRowsBackfillMissingCells(): void
+    {
+        // Regression: differing column sets used to emit "undefined array key" warnings.
+        $content = Table::create()
+            ->row(['a' => 'x', 'b' => 'y'])
+            ->row(['a' => 'z'])
+            ->getContent();
+
+        self::assertStringContainsString('[NULL]', $content);
+    }
+
+    public function testValueStringification(): void
+    {
+        $resource = \fopen('php://memory', 'r');
+        $content = Table::create()
+            ->row([
+                'nullv' => null,
+                'truev' => true,
+                'falsev' => false,
+                'arr' => [1, 2],
+                'obj' => new \stdClass(),
+                'res' => $resource,
+            ])
+            ->getContent();
+        if (\is_resource($resource)) {
+            \fclose($resource);
+        }
+
+        self::assertStringContainsString('[NULL]', $content);
+        self::assertStringContainsString('[TRUE]', $content);
+        self::assertStringContainsString('[FALSE]', $content);
+        self::assertStringContainsString('[ARRAY]', $content);
+        self::assertStringContainsString('[RESOURCE]', $content);
+        self::assertStringContainsString('stdClass', $content);
+    }
+
+    public function testCallableArrayIsLabelled(): void
+    {
+        $content = Table::create()
+            ->row(['cb' => [$this, 'testCallableArrayIsLabelled']])
+            ->getContent();
+
+        self::assertStringContainsString('[CALLABLE]', $content);
+    }
+
+    public function testStylesEmitEscapeSequences(): void
+    {
+        $content = Table::create()
+            ->setBorderStyle(Table::COLOR_BLUE)
+            ->setHeaderStyle(Table::COLOR_RED, Table::BOLD)
+            ->setCellStyle(Table::COLOR_GREEN)
+            ->row(['id' => 1])
+            ->getContent();
+
+        self::assertStringContainsString("\e[34m", $content); // border blue
+        self::assertStringContainsString("\e[31;1m", $content); // header red+bold
+        self::assertStringContainsString("\e[32m", $content); // cell green
+    }
+
+    public function testColumnCellStyleAppliesToBodyOnly(): void
+    {
+        $content = Table::create()
+            ->setColumnCellStyle('id', Table::COLOR_YELLOW)
+            ->row(['id' => 1, 'name' => 'Ada'])
+            ->getContent();
+
+        self::assertStringContainsString("\e[33m", $content);
+    }
+
+    public function testMultibyteValuesRenderWithoutError(): void
+    {
+        $content = Table::create()
+            ->row(['ad' => 'Mühammet', 'şehir' => 'İstanbul'])
+            ->getContent();
+
+        self::assertStringContainsString('Mühammet', $content);
+        self::assertStringContainsString('İstanbul', $content);
+    }
+
+    public function testLegacyClassAliasResolvesToTable(): void
+    {
+        self::assertTrue(\class_exists('InitPHP\\CLITable\\Table'));
+        self::assertInstanceOf(Table::class, new \InitPHP\CLITable\Table());
+    }
+}


### PR DESCRIPTION
…ache deps, run standards, analysis, tests. Update README, gitignore

<!--
Thanks for sending a pull request! Please:
- Read CONTRIBUTING.md if you haven't: https://github.com/InitPHP/.github/blob/main/CONTRIBUTING.md
- Open one PR per repository — cross-repo changes need a separate PR in each repo, linked in the description.
- Keep the PR focused on one change. If you spotted unrelated improvements, please send them as separate PRs.
-->

## Summary

<!-- One or two sentences: what does this PR do, and why? Focus on the why — the diff already shows the what. -->

## Type of change

<!-- Check all that apply. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behaviour in an incompatible way)
- [ ] 📖 Documentation update
- [ ] 🔧 Refactor / internal change (no behaviour change)
- [ ] ✅ Tests only
- [ ] 🚀 CI / build / tooling

## Linked issues

<!-- e.g. "Closes #123" / "Refs #456" / "Related: InitPHP/HTTP#42" for cross-repo work. -->

## How was this tested?

<!--
Describe the tests you ran and any manual verification steps.
Paste relevant output (test runs, before/after) if helpful.
If this PR adds or changes behaviour, it should also add or update a test.
-->

## Breaking changes

<!--
If you checked "Breaking change" above, describe:
- What breaks (which public API, signature, behaviour)
- The migration path users need to take
- Whether a BC shim (class_alias, deprecation wrapper) was added or considered
Otherwise, write "N/A".
-->

## Checklist

- [ ] Code follows PSR-12 and the project's existing style (PHP-CS-Fixer if available, no warnings)
- [ ] `declare(strict_types=1);` is present in any new PHP files in `src/`
- [ ] Public methods have proper type declarations (parameters and return types)
- [ ] Tests cover the change — added new tests or updated existing ones (N/A for docs-only PRs)
- [ ] PHPStan passes locally at the level configured in the package
- [ ] PHPUnit passes locally (`composer test` or `vendor/bin/phpunit`)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have read and agree to the [Code of Conduct](https://github.com/InitPHP/.github/blob/main/CODE_OF_CONDUCT.md)
